### PR TITLE
ci(#19): add CI workflow for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
             \$c['repositories'] = [['type' => 'path', 'url' => '../waaseyaa/packages/*']];
             file_put_contents('composer.json', json_encode(\$c, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . \"\\n\");
           "
+          rm -f composer.lock
 
       - name: Install dependencies
         working-directory: myclaudia


### PR DESCRIPTION
## Summary
- Add `ci.yml` workflow triggered on pushes to main and PRs
- PHPUnit job: runs Unit suite on PHP 8.4
- Lint job: `composer validate` + PHP syntax check
- Checks out waaseyaa/framework alongside, rewrites Composer path repos for CI

## Test plan
- [ ] CI runs and passes on this PR

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)