### PR TITLE
feat: add deploy scripts and workspace templates

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy: merge main into release branch
+# Usage: bin/deploy [tag]
+# Example: bin/deploy v0.2
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_DIR"
+
+# Ensure we're on main and clean
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "Error: Must be on main branch (currently on $CURRENT_BRANCH)"
+    exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: Working tree is not clean. Commit or stash changes first."
+    exit 1
+fi
+
+# Merge main into release
+git checkout release
+git merge main --no-edit
+echo "✓ Merged main into release"
+
+# Optional tag
+if [ -n "${1:-}" ]; then
+    git tag "$1"
+    echo "✓ Tagged $1"
+fi
+
+git push origin release --tags
+echo "✓ Pushed release branch"
+
+git checkout main
+echo "✓ Back on main"
+echo ""
+echo "To update installed copy:"
+echo "  cd ~/myclaudia && git pull"

--- a/bin/setup-install
+++ b/bin/setup-install
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Setup: clone repo and configure as installed copy
+# Usage: bin/setup-install [target-dir]
+# Default target: ~/myclaudia
+
+TARGET="${1:-$HOME/myclaudia}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+if [ -d "$TARGET" ]; then
+    echo "Error: $TARGET already exists. Remove it first or choose a different path."
+    exit 1
+fi
+
+echo "Setting up MyClaudia at $TARGET..."
+
+# Clone and checkout release
+git clone "$REPO_DIR" "$TARGET"
+cd "$TARGET"
+git checkout release 2>/dev/null || git checkout -b release
+
+# Create user-data directories
+mkdir -p context people projects .firecrawl workspaces
+
+# Install the user-facing constitution
+if [ -f CLAUDE.user.md ]; then
+    cp CLAUDE.user.md CLAUDE.md
+    echo "✓ Installed user-facing CLAUDE.md"
+fi
+
+# Install PHP dependencies (production only)
+if command -v composer &> /dev/null; then
+    composer install --no-dev --no-interaction --quiet
+    echo "✓ Installed PHP dependencies"
+else
+    echo "⚠ Composer not found — run 'composer install --no-dev' manually"
+fi
+
+echo ""
+echo "✓ MyClaudia installed at $TARGET"
+echo ""
+echo "Next steps:"
+echo "  1. Copy user data from old installation:"
+echo "     rsync -av ~/claudia/context/ $TARGET/context/"
+echo "     rsync -av ~/claudia/people/ $TARGET/people/"
+echo "     rsync -av ~/claudia/projects/ $TARGET/projects/"
+echo "     rsync -av ~/claudia/.firecrawl/ $TARGET/.firecrawl/"
+echo "  2. Verify: cd $TARGET && claude"

--- a/workspaces/_templates/Agreement.md
+++ b/workspaces/_templates/Agreement.md
@@ -1,0 +1,25 @@
+---
+type: workspace-agreement
+agreement_type: ""
+status: ""
+signed_date: null
+parties: []
+value: 0
+tags:
+  - workspace
+  - agreement
+---
+
+# {{agreement_title}}
+
+> **Type:** {{agreement_type}} | **Status:** {{status}}
+
+## Key Terms
+
+## Filesystem Reference
+
+`{{filesystem_path}}`
+
+## Changes from Previous Version
+
+-

--- a/workspaces/_templates/Dashboard.md
+++ b/workspaces/_templates/Dashboard.md
@@ -1,0 +1,67 @@
+---
+type: workspace-dashboard
+project: ""
+client: ""
+sponsor: ""
+status: active
+phase: ""
+fee: 0
+paid: 0
+health: ""
+filesystem_root: ""
+sync:
+  mappings: []
+  slug_to_name: {}
+tags:
+  - workspace
+---
+
+# {{project}}
+
+> [!info] Quick Links
+> - Client: [[{{client}}]]
+> - Sponsor: [[{{sponsor}}]]
+> - Filesystem: `{{filesystem_root}}`
+
+## Phase Tracker
+
+| Phase | Description | Timeline | Status |
+|-------|-------------|----------|--------|
+| Phase 1 | | | |
+| Phase 2 | | | |
+| Phase 3 | | | |
+
+## What We Owe Them
+
+| Item | Status | Due | Notes |
+|------|--------|-----|-------|
+
+## What They Owe Us
+
+| Item | Who | Status | Notes |
+|------|-----|--------|-------|
+
+## Interview Progress
+
+```dataview
+TABLE status, date, person
+FROM "workspaces/{{project-slug}}/interviews"
+SORT date DESC
+```
+
+## Deliverable Status
+
+```dataview
+TABLE status, evidence_strength
+FROM "workspaces/{{project-slug}}/deliverables"
+SORT file.name ASC
+```
+
+## Recent Meetings
+
+```dataview
+TABLE date, attendees, meeting_type
+FROM "workspaces/{{project-slug}}/meetings"
+SORT date DESC
+LIMIT 5
+```

--- a/workspaces/_templates/Deliverable.md
+++ b/workspaces/_templates/Deliverable.md
@@ -1,0 +1,30 @@
+---
+type: workspace-deliverable
+deliverable_number: 0
+title: ""
+status: not_started
+evidence_strength: thin
+key_sources: []
+tags:
+  - workspace
+  - deliverable
+---
+
+# D{{deliverable_number}} - {{title}}
+
+## Description
+
+*(From SOW Section 2)*
+
+## Evidence Tracker
+
+| Source | What They Contribute | Strength |
+|--------|---------------------|----------|
+
+## Gaps Remaining
+
+- [ ]
+
+## Themes Connected
+
+-

--- a/workspaces/_templates/Interview.md
+++ b/workspaces/_templates/Interview.md
@@ -1,0 +1,66 @@
+---
+type: workspace-interview
+person: ""
+role: ""
+email: ""
+entity: ""
+entity_division: ""
+stance: unknown
+status: not_scheduled
+date: null
+interviewer: ""
+assessment_scores:
+  ai_comfort: null
+  change_readiness: null
+  tech_savviness: null
+  data_awareness: null
+  process_maturity: null
+  influence: null
+tags:
+  - workspace
+  - interview
+---
+
+# {{person}} - Interview
+
+> **Role:** {{role}}
+> **Entity:** {{entity}} ({{entity_division}})
+> **Stance:** {{stance}}
+> **Status:** {{status}}
+
+## Filesystem References
+
+| Document | Path |
+|----------|------|
+| Questions | `{{questions_path}}` |
+| Transcript | `{{transcript_path}}` |
+| Insights | `{{insights_path}}` |
+
+## Key Findings
+
+*(Populated after interview)*
+
+## Assessment Scores
+
+| Dimension | Score | Evidence |
+|-----------|-------|----------|
+| AI Comfort | /5 | |
+| Change Readiness | /5 | |
+| Tech Savviness | /5 | |
+| Data Awareness | /5 | |
+| Process Maturity | /5 | |
+| Influence | /5 | |
+
+## Deliverable Contributions
+
+| Deliverable | Relevant Insights | Strength |
+|-------------|------------------|----------|
+
+## Themes Touched
+
+-
+
+## Stakeholder Connections
+
+| Person | Relationship | Dynamic |
+|--------|-------------|---------|

--- a/workspaces/_templates/Invoice.md
+++ b/workspaces/_templates/Invoice.md
@@ -1,0 +1,41 @@
+---
+type: workspace-invoice
+invoice_number: ""
+client: ""
+amount: 0
+date_sent: null
+date_due: null
+status: sent
+filesystem_path: ""
+tags:
+  - workspace
+  - invoice
+---
+
+# {{invoice_number}}
+
+> **Client:** {{client}} | **Amount:** ${{amount}} | **Status:** {{status}}
+
+## Details
+
+| Field | Value |
+|-------|-------|
+| Invoice Number | {{invoice_number}} |
+| Amount | ${{amount}} |
+| Date Sent | {{date_sent}} |
+| Date Due | {{date_due}} |
+| Status | {{status}} |
+| Payment Received | |
+
+## Line Items
+
+| Description | Amount |
+|-------------|--------|
+| | |
+
+## Filesystem Reference
+
+`{{filesystem_path}}`
+
+## Notes
+

--- a/workspaces/_templates/Meeting.md
+++ b/workspaces/_templates/Meeting.md
@@ -1,0 +1,28 @@
+---
+type: workspace-meeting
+date: null
+attendees: []
+meeting_type: ""
+duration: ""
+tags:
+  - workspace
+  - meeting
+---
+
+# {{meeting_title}}
+
+> **Date:** {{date}} | **Type:** {{meeting_type}} | **Duration:** {{duration}}
+
+## Attendees
+
+## Summary
+
+## Decisions Made
+
+## Action Items
+
+- [ ]
+
+## Themes Surfaced
+
+-

--- a/workspaces/_templates/Pipeline.md
+++ b/workspaces/_templates/Pipeline.md
@@ -1,0 +1,32 @@
+---
+type: workspace-pipeline
+entity: ""
+tags:
+  - workspace
+  - pipeline
+---
+
+# {{entity}} - Pipeline
+
+## Active Engagements
+
+| Client | Phase | Value | Health | Next Action |
+|--------|-------|-------|--------|-------------|
+
+## Warm Leads
+
+| Contact | Source | Interest | Next Step |
+|---------|--------|----------|-----------|
+
+## Network Opportunities
+
+| Contact | Opportunity | Source | Status |
+|---------|-------------|--------|--------|
+
+## Capacity
+
+| Metric | Value |
+|--------|-------|
+| Current active clients | |
+| Max simultaneous clients | |
+| Available capacity | |

--- a/workspaces/_templates/Theme.md
+++ b/workspaces/_templates/Theme.md
@@ -1,0 +1,28 @@
+---
+type: workspace-theme
+confidence: emerging
+source_count: 0
+tags:
+  - workspace
+  - theme
+---
+
+# {{theme_name}}
+
+> **Confidence:** {{confidence}} | **Sources:** {{source_count}}
+
+## Description
+
+## Supporting Evidence
+
+| Source | Evidence | Date |
+|--------|----------|------|
+
+## Implications for Deliverables
+
+| Deliverable | How This Theme Affects It |
+|-------------|-------------------------|
+
+## Tensions
+
+-

--- a/workspaces/_templates/Timeline.md
+++ b/workspaces/_templates/Timeline.md
@@ -1,0 +1,12 @@
+---
+type: workspace-timeline
+project: ""
+tags:
+  - workspace
+  - timeline
+---
+
+# {{project}} - Timeline
+
+| Date | Event | Links |
+|------|-------|-------|


### PR DESCRIPTION
## Summary

- **`bin/deploy`** — merges `main` into `release` branch, optionally tags, and pushes. Used to promote tested code to the installed copy.
- **`bin/setup-install`** — clones the repo to a target directory, checks out `release`, creates user-data directories, installs PHP deps, and prints next-step instructions for migrating data.
- **`workspaces/_templates/`** — 9 Markdown templates (Agreement, Dashboard, Deliverable, Interview, Invoice, Meeting, Pipeline, Theme, Timeline) that provide structure for active workspaces.

## Test plan

- [ ] Verify `bin/deploy` is executable and fails gracefully when not on `main`
- [ ] Verify `bin/setup-install` is executable and refuses to overwrite existing target
- [ ] Confirm all 9 workspace templates are present in `workspaces/_templates/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)