### PR TITLE
fix(#36): nav link contrast — Brief text invisible

### DIFF
--- a/templates/day-brief.html.twig
+++ b/templates/day-brief.html.twig
@@ -50,8 +50,8 @@
             margin: 0.75rem 0 0.4rem;
             text-transform: capitalize;
         }
-        ul { list-style: none; padding: 0; }
-        li {
+        main ul { list-style: none; padding: 0; }
+        main li {
             padding: 0.5rem 0.75rem;
             margin-bottom: 0.35rem;
             background: #fff;
@@ -59,7 +59,7 @@
             border-left: 3px solid #ccc;
             font-size: 0.9rem;
         }
-        li .meta {
+        main li .meta {
             display: block;
             font-size: 0.78rem;
             color: #888;
@@ -145,6 +145,7 @@
         </div>
     </nav>
 
+    <main>
     <h1>
         Day Brief
         <small>Generated {{ "now"|date("Y-m-d H:i T") }}</small>
@@ -229,5 +230,6 @@
             <p class="empty">No drifting commitments — all on track.</p>
         {% endif %}
     </section>
+    </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Scopes `ul`/`li` styles to `main` element so nav links aren't affected
- Wraps brief content in `<main>` tag
- Fixes #36

## Test plan
- [x] 46 tests pass
- [x] Visual verification — "Brief" text now visible in nav bar
- [x] No change to brief content layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)