### PR TITLE
feat(#41): Claudia → MyClaudia event bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# MyClaudia Configuration
+# Copy to .env and fill in values
+
+# API authentication key for ingestion endpoint
+MYCLAUDIA_API_KEY=change-me-to-a-random-string
+
+# API base URL (default for local development)
+MYCLAUDIA_API_URL=http://localhost:8088
+
+# Anthropic API key (for chat interface)
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Anthropic model (default: claude-sonnet-4-5-20250514)
+ANTHROPIC_MODEL=claude-sonnet-4-5-20250514

--- a/bin/mc-ingest
+++ b/bin/mc-ingest
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mc-ingest: Send an event to MyClaudia ingestion API
+# Usage: mc-ingest <type> <json-payload>
+# Example: mc-ingest commitment.detected '{"title":"Send proposal","confidence":0.85}'
+#
+# Environment:
+#   MYCLAUDIA_API_URL  — API base URL (default: http://localhost:8088)
+#   MYCLAUDIA_API_KEY  — Bearer token (required, or read from .env)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load config
+MC_API_URL="${MYCLAUDIA_API_URL:-http://localhost:8088}"
+
+# Try env var first, then .env file
+if [ -z "${MYCLAUDIA_API_KEY:-}" ] && [ -f "$REPO_DIR/.env" ]; then
+    MYCLAUDIA_API_KEY="$(grep -E '^MYCLAUDIA_API_KEY=' "$REPO_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d "'\"")"
+fi
+
+if [ -z "${MYCLAUDIA_API_KEY:-}" ]; then
+    echo "Error: MYCLAUDIA_API_KEY not set. Add it to .env or export it." >&2
+    exit 1
+fi
+
+EVENT_TYPE="${1:?Usage: mc-ingest <type> <json-payload>}"
+PAYLOAD="${2:?Usage: mc-ingest <type> <json-payload>}"
+
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$MC_API_URL/api/ingest" \
+  -H "Authorization: Bearer $MYCLAUDIA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(printf '{"source":"claudia","type":"%s","occurred":"%s","payload":%s}' \
+    "$EVENT_TYPE" \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$PAYLOAD"
+  )" 2>&1)
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+    echo "$BODY"
+else
+    echo "Error: HTTP $HTTP_CODE" >&2
+    echo "$BODY" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `bin/mc-ingest` shell script that POSTs events to MyClaudia ingestion API with Bearer token auth
- Adds `.env.example` documenting required configuration variables (API key, Anthropic key, etc.)
- `.env` already gitignored

## Usage
```bash
bin/mc-ingest commitment.detected '{"title":"Send proposal","confidence":0.85}'
bin/mc-ingest meeting.captured '{"participants":["sarah@example.com"],"decisions":["Go with vendor A"]}'
```

## Dependencies
- Depends on #40 for the server-side `/api/ingest` endpoint (script can be merged independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)