### PR TITLE
feat(#40,#44): ingestion API + read API endpoints

### DIFF
--- a/src/Controller/ContextController.php
+++ b/src/Controller/ContextController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Controller;
+
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\SsrResponse;
+
+/**
+ * GET /api/context — composite endpoint returning brief + context files.
+ *
+ * HttpKernel calls: new $class($entityTypeManager, $twig)
+ * then: $instance->show($params, $query, $account, $httpRequest)
+ */
+final class ContextController
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly mixed $twig = null,
+    ) {}
+
+    public function show(array $params = [], array $query = [], mixed $account = null, mixed $httpRequest = null): SsrResponse
+    {
+        $projectRoot = getenv('MYCLAUDIA_PROJECT_ROOT') ?: dirname(__DIR__, 2);
+
+        // Load recent events.
+        $eventStorage = $this->entityTypeManager->getStorage('mc_event');
+        $allEventIds = $eventStorage->getQuery()->execute();
+        $allEvents = $eventStorage->loadMultiple($allEventIds);
+
+        $since = new \DateTimeImmutable('-24 hours');
+        $recentEvents = array_values(array_filter(
+            $allEvents,
+            fn ($e) => new \DateTimeImmutable($e->get('occurred') ?? 'now') >= $since,
+        ));
+
+        // Load pending commitments.
+        $commitmentStorage = $this->entityTypeManager->getStorage('commitment');
+        $allCommitmentIds = $commitmentStorage->getQuery()->execute();
+        $allCommitments = $commitmentStorage->loadMultiple($allCommitmentIds);
+        $pendingCommitments = array_values(array_filter(
+            $allCommitments,
+            fn ($c) => $c->get('status') === 'pending',
+        ));
+
+        // Drifting commitments (active + updated_at < 48h).
+        $driftingCommitments = array_values(array_filter(
+            $allCommitments,
+            fn ($c) => $c->get('status') === 'active'
+                && ($c->get('updated_at') ?? null) !== null
+                && new \DateTimeImmutable($c->get('updated_at')) < new \DateTimeImmutable('-48 hours'),
+        ));
+
+        $brief = [
+            'recent_events'        => array_map(fn ($e) => $e->toArray(), $recentEvents),
+            'pending_commitments'  => array_map(fn ($c) => $c->toArray(), $pendingCommitments),
+            'drifting_commitments' => array_map(fn ($c) => $c->toArray(), $driftingCommitments),
+        ];
+
+        $contextFiles = [
+            'me'          => $this->readContextFile($projectRoot . '/context/me.md'),
+            'commitments' => $this->readContextFile($projectRoot . '/context/commitments.md'),
+            'patterns'    => $this->readContextFile($projectRoot . '/context/patterns.md'),
+        ];
+
+        $payload = [
+            'brief'         => $brief,
+            'context_files' => $contextFiles,
+        ];
+
+        return new SsrResponse(
+            content: json_encode($payload, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR),
+            statusCode: 200,
+            headers: ['Content-Type' => 'application/json'],
+        );
+    }
+
+    private function readContextFile(string $path): ?string
+    {
+        if (!is_file($path) || !is_readable($path)) {
+            return null;
+        }
+
+        return file_get_contents($path) ?: null;
+    }
+}

--- a/src/Controller/IngestController.php
+++ b/src/Controller/IngestController.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Controller;
+
+use MyClaudia\Ingestion\Handler\CommitmentIngestHandler;
+use MyClaudia\Ingestion\Handler\GenericEventHandler;
+use MyClaudia\Ingestion\Handler\PersonIngestHandler;
+use MyClaudia\Ingestion\IngestHandlerRegistry;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Entity\EntityTypeManager;
+
+/**
+ * POST /api/ingest — accepts external ingestion payloads.
+ *
+ * HttpKernel calls: new $class($entityTypeManager, $twig)
+ * then: $instance->handle($params, $query, $account, $httpRequest)
+ */
+final class IngestController
+{
+    private readonly IngestHandlerRegistry $registry;
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly mixed $twig = null,
+    ) {
+        $fallback = new GenericEventHandler($this->entityTypeManager);
+        $this->registry = new IngestHandlerRegistry($fallback);
+        $this->registry->addHandler(new CommitmentIngestHandler($this->entityTypeManager));
+        $this->registry->addHandler(new PersonIngestHandler($this->entityTypeManager));
+    }
+
+    public function handle(array $params = [], array $query = [], mixed $account = null, mixed $httpRequest = null): JsonResponse
+    {
+        // Validate bearer token.
+        $token = $this->extractBearerToken($httpRequest);
+        $validKeys = $this->getValidApiKeys();
+
+        if ($token === null || $validKeys === [] || !in_array($token, $validKeys, true)) {
+            return new JsonResponse(['error' => 'Unauthorized'], 401);
+        }
+
+        $raw = $httpRequest instanceof Request ? $httpRequest->getContent() : '';
+        $data = json_decode($raw, true);
+
+        if (!is_array($data) || !isset($data['source'], $data['type'], $data['payload'])) {
+            return new JsonResponse([
+                'error'    => 'Invalid payload',
+                'required' => ['source', 'type', 'payload'],
+            ], 422);
+        }
+
+        if (!is_array($data['payload'])) {
+            return new JsonResponse([
+                'error' => 'Invalid payload: "payload" must be an object',
+            ], 422);
+        }
+
+        $result = $this->registry->handle($data);
+
+        return new JsonResponse($result, 201);
+    }
+
+    private function extractBearerToken(mixed $httpRequest): ?string
+    {
+        if (!$httpRequest instanceof Request) {
+            return null;
+        }
+
+        $header = $httpRequest->headers->get('Authorization', '');
+        if (!is_string($header) || !str_starts_with($header, 'Bearer ')) {
+            return null;
+        }
+
+        $token = substr($header, 7);
+
+        return $token !== '' ? $token : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getValidApiKeys(): array
+    {
+        $key = $_ENV['MYCLAUDIA_API_KEY']
+            ?? getenv('MYCLAUDIA_API_KEY')
+            ?: null;
+
+        if ($key === null || $key === '' || $key === false) {
+            return [];
+        }
+
+        return [(string) $key];
+    }
+}

--- a/src/Ingestion/Handler/CommitmentIngestHandler.php
+++ b/src/Ingestion/Handler/CommitmentIngestHandler.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Ingestion\Handler;
+
+use MyClaudia\Entity\Commitment;
+use MyClaudia\Entity\Person;
+use MyClaudia\Ingestion\IngestHandlerInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+
+/**
+ * Creates a Commitment entity and upserts a Person from commitment.detected events.
+ */
+final class CommitmentIngestHandler implements IngestHandlerInterface
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+    ) {}
+
+    public function supports(string $type): bool
+    {
+        return $type === 'commitment.detected';
+    }
+
+    public function handle(array $data): array
+    {
+        $payload = $data['payload'];
+
+        // Upsert person if email is provided.
+        $personUuid = null;
+        $email = $payload['person_email'] ?? null;
+        if (is_string($email) && $email !== '') {
+            $personUuid = $this->upsertPerson(
+                $email,
+                $payload['person_name'] ?? $email,
+            );
+        }
+
+        $commitment = new Commitment([
+            'title'      => $payload['title'] ?? 'Untitled commitment',
+            'confidence' => $payload['confidence'] ?? 1.0,
+            'status'     => 'pending',
+            'due_date'   => $payload['due_date'] ?? null,
+            'source'     => $data['source'],
+        ]);
+
+        $storage = $this->entityTypeManager->getStorage('commitment');
+        $storage->save($commitment);
+
+        return [
+            'status'      => 'created',
+            'entity_type' => 'commitment',
+            'uuid'        => $commitment->uuid(),
+            'person_uuid' => $personUuid,
+        ];
+    }
+
+    private function upsertPerson(string $email, string $name): ?string
+    {
+        $storage = $this->entityTypeManager->getStorage('person');
+        $query = $storage->getQuery();
+        $query->accessCheck(false);
+        $query->condition('email', $email);
+        $ids = $query->execute();
+
+        if ($ids !== []) {
+            $person = $storage->load(reset($ids));
+            return $person?->uuid();
+        }
+
+        $person = new Person([
+            'email' => $email,
+            'name'  => $name,
+        ]);
+        $storage->save($person);
+
+        return $person->uuid();
+    }
+}

--- a/src/Ingestion/Handler/GenericEventHandler.php
+++ b/src/Ingestion/Handler/GenericEventHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Ingestion\Handler;
+
+use MyClaudia\Entity\McEvent;
+use MyClaudia\Ingestion\IngestHandlerInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+
+/**
+ * Stores any ingestion event as a McEvent entity.
+ *
+ * Used as the fallback handler when no specific handler matches the event type.
+ */
+final class GenericEventHandler implements IngestHandlerInterface
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+    ) {}
+
+    public function supports(string $type): bool
+    {
+        return true;
+    }
+
+    public function handle(array $data): array
+    {
+        $event = new McEvent([
+            'source'   => $data['source'],
+            'type'     => $data['type'],
+            'payload'  => json_encode($data['payload'], JSON_THROW_ON_ERROR),
+            'occurred' => date('Y-m-d H:i:s'),
+        ]);
+
+        $storage = $this->entityTypeManager->getStorage('mc_event');
+        $storage->save($event);
+
+        return [
+            'status'      => 'created',
+            'entity_type' => 'mc_event',
+            'uuid'        => $event->uuid(),
+        ];
+    }
+}

--- a/src/Ingestion/Handler/PersonIngestHandler.php
+++ b/src/Ingestion/Handler/PersonIngestHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Ingestion\Handler;
+
+use MyClaudia\Entity\Person;
+use MyClaudia\Ingestion\IngestHandlerInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+
+/**
+ * Upserts a Person entity from person.created events.
+ */
+final class PersonIngestHandler implements IngestHandlerInterface
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+    ) {}
+
+    public function supports(string $type): bool
+    {
+        return $type === 'person.created';
+    }
+
+    public function handle(array $data): array
+    {
+        $payload = $data['payload'];
+        $email = $payload['email'] ?? '';
+
+        if ($email === '') {
+            return [
+                'status'  => 'error',
+                'message' => 'Missing required field: email',
+            ];
+        }
+
+        $storage = $this->entityTypeManager->getStorage('person');
+
+        // Check for existing person by email.
+        $query = $storage->getQuery();
+        $query->accessCheck(false);
+        $query->condition('email', $email);
+        $ids = $query->execute();
+
+        if ($ids !== []) {
+            // Update existing person.
+            $person = $storage->load(reset($ids));
+            if ($person !== null) {
+                $name = $payload['name'] ?? null;
+                if (is_string($name) && $name !== '') {
+                    $person->set('name', $name);
+                    $storage->save($person);
+                }
+
+                return [
+                    'status'      => 'updated',
+                    'entity_type' => 'person',
+                    'uuid'        => $person->uuid(),
+                ];
+            }
+        }
+
+        $person = new Person([
+            'email' => $email,
+            'name'  => $payload['name'] ?? $email,
+        ]);
+        $storage->save($person);
+
+        return [
+            'status'      => 'created',
+            'entity_type' => 'person',
+            'uuid'        => $person->uuid(),
+        ];
+    }
+}

--- a/src/Ingestion/IngestHandlerInterface.php
+++ b/src/Ingestion/IngestHandlerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Ingestion;
+
+/**
+ * Handles a specific ingestion event type.
+ */
+interface IngestHandlerInterface
+{
+    /**
+     * Whether this handler supports the given event type.
+     */
+    public function supports(string $type): bool;
+
+    /**
+     * Process the ingestion payload and return a result array.
+     *
+     * @param array{source: string, type: string, payload: array<string, mixed>} $data
+     * @return array<string, mixed>
+     */
+    public function handle(array $data): array;
+}

--- a/src/Ingestion/IngestHandlerRegistry.php
+++ b/src/Ingestion/IngestHandlerRegistry.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Ingestion;
+
+/**
+ * Routes ingestion payloads to the appropriate handler based on event type.
+ *
+ * Falls back to GenericEventHandler for unknown types.
+ */
+final class IngestHandlerRegistry
+{
+    /** @var list<IngestHandlerInterface> */
+    private array $handlers = [];
+
+    private IngestHandlerInterface $fallback;
+
+    public function __construct(IngestHandlerInterface $fallback)
+    {
+        $this->fallback = $fallback;
+    }
+
+    public function addHandler(IngestHandlerInterface $handler): void
+    {
+        $this->handlers[] = $handler;
+    }
+
+    /**
+     * @param array{source: string, type: string, payload: array<string, mixed>} $data
+     * @return array<string, mixed>
+     */
+    public function handle(array $data): array
+    {
+        $type = $data['type'];
+
+        foreach ($this->handlers as $handler) {
+            if ($handler->supports($type)) {
+                return $handler->handle($data);
+            }
+        }
+
+        return $this->fallback->handle($data);
+    }
+}

--- a/src/Provider/McClaudiaServiceProvider.php
+++ b/src/Provider/McClaudiaServiceProvider.php
@@ -9,7 +9,9 @@ use MyClaudia\Command\CommitmentUpdateCommand;
 use MyClaudia\Command\CommitmentsCommand;
 use MyClaudia\Command\SkillsCommand;
 use MyClaudia\Controller\CommitmentUpdateController;
+use MyClaudia\Controller\ContextController;
 use MyClaudia\Controller\DayBriefController;
+use MyClaudia\Controller\IngestController;
 use MyClaudia\Domain\DayBrief\Assembler\DayBriefAssembler;
 use MyClaudia\Domain\DayBrief\Service\BriefSessionStore;
 use MyClaudia\Support\DriftDetector;
@@ -103,6 +105,26 @@ final class McClaudiaServiceProvider extends ServiceProvider
                 ->controller(CommitmentUpdateController::class . '::update')
                 ->allowAll()
                 ->methods('PATCH')
+                ->build(),
+        );
+
+        // POST /api/ingest — external ingestion endpoint.
+        $router->addRoute(
+            'myclaudia.api.ingest',
+            RouteBuilder::create('/api/ingest')
+                ->controller(IngestController::class . '::handle')
+                ->allowAll()
+                ->methods('POST')
+                ->build(),
+        );
+
+        // GET /api/context — composite brief + context files.
+        $router->addRoute(
+            'myclaudia.api.context',
+            RouteBuilder::create('/api/context')
+                ->controller(ContextController::class . '::show')
+                ->allowAll()
+                ->methods('GET')
                 ->build(),
         );
     }

--- a/tests/Unit/Controller/ContextControllerTest.php
+++ b/tests/Unit/Controller/ContextControllerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Tests\Unit\Controller;
+
+use MyClaudia\Controller\ContextController;
+use MyClaudia\Entity\Commitment;
+use MyClaudia\Entity\McEvent;
+use Waaseyaa\Database\PdoDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+final class ContextControllerTest extends TestCase
+{
+    private EntityTypeManager $entityTypeManager;
+
+    protected function setUp(): void
+    {
+        $db = PdoDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+
+        $this->entityTypeManager = new EntityTypeManager(
+            $dispatcher,
+            function ($definition) use ($db, $dispatcher): SqlEntityStorage {
+                (new SqlSchemaHandler($definition, $db))->ensureTable();
+                return new SqlEntityStorage($definition, $db, $dispatcher);
+            },
+        );
+
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'mc_event',
+            label: 'Event',
+            class: McEvent::class,
+            keys: ['id' => 'eid', 'uuid' => 'uuid'],
+        ));
+
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'commitment',
+            label: 'Commitment',
+            class: Commitment::class,
+            keys: ['id' => 'cid', 'uuid' => 'uuid', 'label' => 'title'],
+        ));
+    }
+
+    public function testShowReturnsJsonWithBriefAndContextFiles(): void
+    {
+        $controller = new ContextController($this->entityTypeManager, null);
+        $response = $controller->show();
+
+        self::assertSame(200, $response->statusCode);
+        self::assertSame('application/json', $response->headers['Content-Type']);
+
+        $body = json_decode($response->content, true);
+        self::assertIsArray($body);
+        self::assertArrayHasKey('brief', $body);
+        self::assertArrayHasKey('context_files', $body);
+
+        $brief = $body['brief'];
+        self::assertArrayHasKey('recent_events', $brief);
+        self::assertArrayHasKey('pending_commitments', $brief);
+        self::assertArrayHasKey('drifting_commitments', $brief);
+
+        $contextFiles = $body['context_files'];
+        self::assertArrayHasKey('me', $contextFiles);
+        self::assertArrayHasKey('commitments', $contextFiles);
+        self::assertArrayHasKey('patterns', $contextFiles);
+    }
+
+    public function testShowIncludesRecentEvents(): void
+    {
+        $event = new McEvent([
+            'uuid'     => 'eeee0001-0001-0001-0001-eeeeeeeeeeee',
+            'type'     => 'email_received',
+            'source'   => 'gmail',
+            'occurred' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+            'payload'  => json_encode(['subject' => 'Test']),
+        ]);
+        $this->entityTypeManager->getStorage('mc_event')->save($event);
+
+        $controller = new ContextController($this->entityTypeManager, null);
+        $response = $controller->show();
+
+        $body = json_decode($response->content, true);
+        self::assertNotEmpty($body['brief']['recent_events']);
+    }
+
+    public function testShowIncludesPendingCommitments(): void
+    {
+        $commitment = new Commitment([
+            'title'  => 'Follow up',
+            'status' => 'pending',
+        ]);
+        $this->entityTypeManager->getStorage('commitment')->save($commitment);
+
+        $controller = new ContextController($this->entityTypeManager, null);
+        $response = $controller->show();
+
+        $body = json_decode($response->content, true);
+        self::assertNotEmpty($body['brief']['pending_commitments']);
+    }
+}

--- a/tests/Unit/Controller/IngestControllerTest.php
+++ b/tests/Unit/Controller/IngestControllerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Tests\Unit\Controller;
+
+use MyClaudia\Controller\IngestController;
+use MyClaudia\Entity\Commitment;
+use MyClaudia\Entity\McEvent;
+use MyClaudia\Entity\Person;
+use Waaseyaa\Database\PdoDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+
+final class IngestControllerTest extends TestCase
+{
+    private EntityTypeManager $entityTypeManager;
+    private IngestController $controller;
+    private string $originalApiKey;
+
+    protected function setUp(): void
+    {
+        $this->originalApiKey = $_ENV['MYCLAUDIA_API_KEY'] ?? '';
+
+        $db = PdoDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+
+        $this->entityTypeManager = new EntityTypeManager(
+            $dispatcher,
+            function ($definition) use ($db, $dispatcher): SqlEntityStorage {
+                (new SqlSchemaHandler($definition, $db))->ensureTable();
+                return new SqlEntityStorage($definition, $db, $dispatcher);
+            },
+        );
+
+        foreach ($this->entityTypeDefinitions() as $type) {
+            $this->entityTypeManager->registerEntityType($type);
+        }
+
+        $_ENV['MYCLAUDIA_API_KEY'] = 'test-secret-key';
+
+        $this->controller = new IngestController($this->entityTypeManager);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalApiKey !== '') {
+            $_ENV['MYCLAUDIA_API_KEY'] = $this->originalApiKey;
+        } else {
+            unset($_ENV['MYCLAUDIA_API_KEY']);
+        }
+    }
+
+    public function testReturns401WithoutBearerToken(): void
+    {
+        $request = Request::create('/api/ingest', 'POST', [], [], [], [], '{}');
+        $response = $this->controller->handle([], [], null, $request);
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function testReturns401WithInvalidToken(): void
+    {
+        $request = Request::create('/api/ingest', 'POST', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer wrong-key',
+        ], '{}');
+        $response = $this->controller->handle([], [], null, $request);
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function testReturns422WithMissingFields(): void
+    {
+        $request = Request::create('/api/ingest', 'POST', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer test-secret-key',
+        ], json_encode(['source' => 'test']));
+        $response = $this->controller->handle([], [], null, $request);
+
+        self::assertSame(422, $response->getStatusCode());
+        $body = json_decode($response->getContent(), true);
+        self::assertSame('Invalid payload', $body['error']);
+    }
+
+    public function testReturns422WithNonObjectPayload(): void
+    {
+        $request = Request::create('/api/ingest', 'POST', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer test-secret-key',
+        ], json_encode(['source' => 'test', 'type' => 'foo', 'payload' => 'string']));
+        $response = $this->controller->handle([], [], null, $request);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function testCreatesGenericEventForUnknownType(): void
+    {
+        $request = Request::create('/api/ingest', 'POST', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer test-secret-key',
+        ], json_encode([
+            'source'  => 'test-source',
+            'type'    => 'some.unknown.event',
+            'payload' => ['key' => 'value'],
+        ]));
+
+        $response = $this->controller->handle([], [], null, $request);
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = json_decode($response->getContent(), true);
+        self::assertSame('created', $body['status']);
+        self::assertSame('mc_event', $body['entity_type']);
+        self::assertNotEmpty($body['uuid']);
+    }
+
+    public function testCreatesCommitmentForCommitmentDetectedType(): void
+    {
+        $request = Request::create('/api/ingest', 'POST', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer test-secret-key',
+        ], json_encode([
+            'source'  => 'gmail',
+            'type'    => 'commitment.detected',
+            'payload' => [
+                'title'        => 'Follow up with Bob',
+                'confidence'   => 0.85,
+                'person_email' => 'bob@example.com',
+                'person_name'  => 'Bob',
+            ],
+        ]));
+
+        $response = $this->controller->handle([], [], null, $request);
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = json_decode($response->getContent(), true);
+        self::assertSame('created', $body['status']);
+        self::assertSame('commitment', $body['entity_type']);
+        self::assertNotEmpty($body['uuid']);
+        self::assertNotEmpty($body['person_uuid']);
+    }
+
+    public function testCreatesPersonForPersonCreatedType(): void
+    {
+        $request = Request::create('/api/ingest', 'POST', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer test-secret-key',
+        ], json_encode([
+            'source'  => 'manual',
+            'type'    => 'person.created',
+            'payload' => [
+                'email' => 'alice@example.com',
+                'name'  => 'Alice',
+            ],
+        ]));
+
+        $response = $this->controller->handle([], [], null, $request);
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = json_decode($response->getContent(), true);
+        self::assertSame('created', $body['status']);
+        self::assertSame('person', $body['entity_type']);
+        self::assertNotEmpty($body['uuid']);
+    }
+
+    /** @return list<EntityType> */
+    private function entityTypeDefinitions(): array
+    {
+        return [
+            new EntityType(
+                id: 'mc_event',
+                label: 'Event',
+                class: McEvent::class,
+                keys: ['id' => 'eid', 'uuid' => 'uuid'],
+            ),
+            new EntityType(
+                id: 'commitment',
+                label: 'Commitment',
+                class: Commitment::class,
+                keys: ['id' => 'cid', 'uuid' => 'uuid', 'label' => 'title'],
+            ),
+            new EntityType(
+                id: 'person',
+                label: 'Person',
+                class: Person::class,
+                keys: ['id' => 'pid', 'uuid' => 'uuid', 'label' => 'name'],
+            ),
+        ];
+    }
+}

--- a/tests/Unit/Ingestion/Handler/CommitmentIngestHandlerTest.php
+++ b/tests/Unit/Ingestion/Handler/CommitmentIngestHandlerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Tests\Unit\Ingestion\Handler;
+
+use MyClaudia\Entity\Commitment;
+use MyClaudia\Entity\Person;
+use MyClaudia\Ingestion\Handler\CommitmentIngestHandler;
+use Waaseyaa\Database\PdoDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+final class CommitmentIngestHandlerTest extends TestCase
+{
+    private EntityTypeManager $entityTypeManager;
+    private CommitmentIngestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $db = PdoDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+
+        $this->entityTypeManager = new EntityTypeManager(
+            $dispatcher,
+            function ($definition) use ($db, $dispatcher): SqlEntityStorage {
+                (new SqlSchemaHandler($definition, $db))->ensureTable();
+                return new SqlEntityStorage($definition, $db, $dispatcher);
+            },
+        );
+
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'commitment',
+            label: 'Commitment',
+            class: Commitment::class,
+            keys: ['id' => 'cid', 'uuid' => 'uuid', 'label' => 'title'],
+        ));
+
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'person',
+            label: 'Person',
+            class: Person::class,
+            keys: ['id' => 'pid', 'uuid' => 'uuid', 'label' => 'name'],
+        ));
+
+        $this->handler = new CommitmentIngestHandler($this->entityTypeManager);
+    }
+
+    public function testSupportsCommitmentDetected(): void
+    {
+        self::assertTrue($this->handler->supports('commitment.detected'));
+        self::assertFalse($this->handler->supports('person.created'));
+    }
+
+    public function testCreatesCommitmentAndPerson(): void
+    {
+        $result = $this->handler->handle([
+            'source' => 'gmail',
+            'type'   => 'commitment.detected',
+            'payload' => [
+                'title'        => 'Follow up with Bob',
+                'confidence'   => 0.9,
+                'person_email' => 'bob@example.com',
+                'person_name'  => 'Bob',
+            ],
+        ]);
+
+        self::assertSame('created', $result['status']);
+        self::assertSame('commitment', $result['entity_type']);
+        self::assertNotEmpty($result['uuid']);
+        self::assertNotEmpty($result['person_uuid']);
+    }
+
+    public function testUpsertsSamePersonOnSecondCall(): void
+    {
+        $data = [
+            'source' => 'gmail',
+            'type'   => 'commitment.detected',
+            'payload' => [
+                'title'        => 'Task 1',
+                'person_email' => 'bob@example.com',
+                'person_name'  => 'Bob',
+            ],
+        ];
+
+        $result1 = $this->handler->handle($data);
+
+        $data['payload']['title'] = 'Task 2';
+        $result2 = $this->handler->handle($data);
+
+        // Same person UUID for both commitments.
+        self::assertSame($result1['person_uuid'], $result2['person_uuid']);
+        // Different commitment UUIDs.
+        self::assertNotSame($result1['uuid'], $result2['uuid']);
+    }
+}

--- a/tests/Unit/Ingestion/Handler/PersonIngestHandlerTest.php
+++ b/tests/Unit/Ingestion/Handler/PersonIngestHandlerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Tests\Unit\Ingestion\Handler;
+
+use MyClaudia\Entity\Person;
+use MyClaudia\Ingestion\Handler\PersonIngestHandler;
+use Waaseyaa\Database\PdoDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+final class PersonIngestHandlerTest extends TestCase
+{
+    private EntityTypeManager $entityTypeManager;
+    private PersonIngestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $db = PdoDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+
+        $this->entityTypeManager = new EntityTypeManager(
+            $dispatcher,
+            function ($definition) use ($db, $dispatcher): SqlEntityStorage {
+                (new SqlSchemaHandler($definition, $db))->ensureTable();
+                return new SqlEntityStorage($definition, $db, $dispatcher);
+            },
+        );
+
+        $this->entityTypeManager->registerEntityType(new EntityType(
+            id: 'person',
+            label: 'Person',
+            class: Person::class,
+            keys: ['id' => 'pid', 'uuid' => 'uuid', 'label' => 'name'],
+        ));
+
+        $this->handler = new PersonIngestHandler($this->entityTypeManager);
+    }
+
+    public function testSupportsPersonCreated(): void
+    {
+        self::assertTrue($this->handler->supports('person.created'));
+        self::assertFalse($this->handler->supports('commitment.detected'));
+    }
+
+    public function testCreatesNewPerson(): void
+    {
+        $result = $this->handler->handle([
+            'source' => 'manual',
+            'type'   => 'person.created',
+            'payload' => [
+                'email' => 'alice@example.com',
+                'name'  => 'Alice',
+            ],
+        ]);
+
+        self::assertSame('created', $result['status']);
+        self::assertSame('person', $result['entity_type']);
+        self::assertNotEmpty($result['uuid']);
+    }
+
+    public function testUpdatesExistingPerson(): void
+    {
+        // Create first.
+        $result1 = $this->handler->handle([
+            'source' => 'manual',
+            'type'   => 'person.created',
+            'payload' => [
+                'email' => 'alice@example.com',
+                'name'  => 'Alice',
+            ],
+        ]);
+
+        // Upsert with same email, new name.
+        $result2 = $this->handler->handle([
+            'source' => 'manual',
+            'type'   => 'person.created',
+            'payload' => [
+                'email' => 'alice@example.com',
+                'name'  => 'Alice Smith',
+            ],
+        ]);
+
+        self::assertSame('updated', $result2['status']);
+        self::assertSame($result1['uuid'], $result2['uuid']);
+    }
+
+    public function testReturnsErrorForMissingEmail(): void
+    {
+        $result = $this->handler->handle([
+            'source' => 'manual',
+            'type'   => 'person.created',
+            'payload' => ['name' => 'No Email'],
+        ]);
+
+        self::assertSame('error', $result['status']);
+    }
+}

--- a/tests/Unit/Ingestion/IngestHandlerRegistryTest.php
+++ b/tests/Unit/Ingestion/IngestHandlerRegistryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyClaudia\Tests\Unit\Ingestion;
+
+use MyClaudia\Ingestion\IngestHandlerInterface;
+use MyClaudia\Ingestion\IngestHandlerRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class IngestHandlerRegistryTest extends TestCase
+{
+    public function testFallsBackToDefaultHandlerForUnknownType(): void
+    {
+        $fallback = $this->createMockHandler(true, ['status' => 'fallback']);
+        $registry = new IngestHandlerRegistry($fallback);
+
+        $result = $registry->handle([
+            'source'  => 'test',
+            'type'    => 'unknown.type',
+            'payload' => [],
+        ]);
+
+        self::assertSame('fallback', $result['status']);
+    }
+
+    public function testRoutesToMatchingHandler(): void
+    {
+        $fallback = $this->createMockHandler(true, ['status' => 'fallback']);
+        $registry = new IngestHandlerRegistry($fallback);
+
+        $specific = new class implements IngestHandlerInterface {
+            public function supports(string $type): bool
+            {
+                return $type === 'test.event';
+            }
+
+            public function handle(array $data): array
+            {
+                return ['status' => 'specific', 'type' => $data['type']];
+            }
+        };
+
+        $registry->addHandler($specific);
+
+        $result = $registry->handle([
+            'source'  => 'test',
+            'type'    => 'test.event',
+            'payload' => [],
+        ]);
+
+        self::assertSame('specific', $result['status']);
+        self::assertSame('test.event', $result['type']);
+    }
+
+    private function createMockHandler(bool $supports, array $result): IngestHandlerInterface
+    {
+        return new class($supports, $result) implements IngestHandlerInterface {
+            public function __construct(
+                private readonly bool $doesSupport,
+                private readonly array $result,
+            ) {}
+
+            public function supports(string $type): bool
+            {
+                return $this->doesSupport;
+            }
+
+            public function handle(array $data): array
+            {
+                return $this->result;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Adds POST /api/ingest (bearer auth, handler registry) and GET /api/context (composite brief). Closes #40, closes #44.