### PR TITLE
refactor(#51): rename CLI commands and env vars to claudriel

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,8 +24,8 @@
       "args": ["tools/memory-mcp/server.js"],
       "cwd": ".",
       "env": {
-        "MYCLAUDIA_API_URL": "http://localhost:8088",
-        "MYCLAUDIA_API_KEY": "${MYCLAUDIA_API_KEY}"
+        "CLAUDRIEL_API_URL": "http://localhost:8088",
+        "CLAUDRIEL_API_KEY": "${CLAUDRIEL_API_KEY}"
       }
     }
   }

--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@
 # Copy to .env and fill in values
 
 # API authentication key for ingestion endpoint
-MYCLAUDIA_API_KEY=change-me-to-a-random-string
+CLAUDRIEL_API_KEY=change-me-to-a-random-string
 
 # API base URL (default for local development)
-MYCLAUDIA_API_URL=http://localhost:8088
+CLAUDRIEL_API_URL=http://localhost:8088
 
 # Anthropic API key (for chat interface)
 ANTHROPIC_API_KEY=sk-ant-...

--- a/bin/mc-ingest
+++ b/bin/mc-ingest
@@ -6,22 +6,22 @@ set -euo pipefail
 # Example: mc-ingest commitment.detected '{"title":"Send proposal","confidence":0.85}'
 #
 # Environment:
-#   MYCLAUDIA_API_URL  — API base URL (default: http://localhost:8088)
-#   MYCLAUDIA_API_KEY  — Bearer token (required, or read from .env)
+#   CLAUDRIEL_API_URL  — API base URL (default: http://localhost:8088)
+#   CLAUDRIEL_API_KEY  — Bearer token (required, or read from .env)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 # Load config
-MC_API_URL="${MYCLAUDIA_API_URL:-http://localhost:8088}"
+MC_API_URL="${CLAUDRIEL_API_URL:-http://localhost:8088}"
 
 # Try env var first, then .env file
-if [ -z "${MYCLAUDIA_API_KEY:-}" ] && [ -f "$REPO_DIR/.env" ]; then
-    MYCLAUDIA_API_KEY="$(grep -E '^MYCLAUDIA_API_KEY=' "$REPO_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d "'\"")"
+if [ -z "${CLAUDRIEL_API_KEY:-}" ] && [ -f "$REPO_DIR/.env" ]; then
+    CLAUDRIEL_API_KEY="$(grep -E '^CLAUDRIEL_API_KEY=' "$REPO_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d "'\"")"
 fi
 
-if [ -z "${MYCLAUDIA_API_KEY:-}" ]; then
-    echo "Error: MYCLAUDIA_API_KEY not set. Add it to .env or export it." >&2
+if [ -z "${CLAUDRIEL_API_KEY:-}" ]; then
+    echo "Error: CLAUDRIEL_API_KEY not set. Add it to .env or export it." >&2
     exit 1
 fi
 
@@ -29,7 +29,7 @@ EVENT_TYPE="${1:?Usage: mc-ingest <type> <json-payload>}"
 PAYLOAD="${2:?Usage: mc-ingest <type> <json-payload>}"
 
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$MC_API_URL/api/ingest" \
-  -H "Authorization: Bearer $MYCLAUDIA_API_KEY" \
+  -H "Authorization: Bearer $CLAUDRIEL_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(printf '{"source":"claudia","type":"%s","occurred":"%s","payload":%s}' \
     "$EVENT_TYPE" \

--- a/src/Command/BriefCommand.php
+++ b/src/Command/BriefCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'myclaudia:brief', description: 'Show your Day Brief')]
+#[AsCommand(name: 'claudriel:brief', description: 'Show your Day Brief')]
 final class BriefCommand extends Command
 {
     public function __construct(

--- a/src/Command/CommitmentUpdateCommand.php
+++ b/src/Command/CommitmentUpdateCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'myclaudia:commitment:update', description: 'Update a commitment status')]
+#[AsCommand(name: 'claudriel:commitment:update', description: 'Update a commitment status')]
 final class CommitmentUpdateCommand extends Command
 {
     private const ACTION_MAP = [

--- a/src/Command/CommitmentsCommand.php
+++ b/src/Command/CommitmentsCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'myclaudia:commitments', description: 'List active commitments')]
+#[AsCommand(name: 'claudriel:commitments', description: 'List active commitments')]
 final class CommitmentsCommand extends Command
 {
     public function __construct(private readonly EntityRepositoryInterface $commitmentRepo)

--- a/src/Command/SkillsCommand.php
+++ b/src/Command/SkillsCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(name: 'myclaudia:skills', description: 'List skills in the vault')]
+#[AsCommand(name: 'claudriel:skills', description: 'List skills in the vault')]
 final class SkillsCommand extends Command
 {
     public function __construct(private readonly EntityRepositoryInterface $skillRepo)

--- a/src/Controller/ChatController.php
+++ b/src/Controller/ChatController.php
@@ -201,8 +201,8 @@ final class ChatController
     private function resolveProjectRoot(): string
     {
         // The project root is the Waaseyaa application root.
-        // Use MYCLAUDIA_ROOT env, or fall back to common detection.
-        $root = getenv('MYCLAUDIA_ROOT');
+        // Use CLAUDRIEL_ROOT env, or fall back to common detection.
+        $root = getenv('CLAUDRIEL_ROOT');
         if (is_string($root) && $root !== '' && is_dir($root)) {
             return $root;
         }

--- a/src/Controller/ContextController.php
+++ b/src/Controller/ContextController.php
@@ -22,7 +22,7 @@ final class ContextController
 
     public function show(array $params = [], array $query = [], mixed $account = null, mixed $httpRequest = null): SsrResponse
     {
-        $projectRoot = getenv('MYCLAUDIA_PROJECT_ROOT') ?: dirname(__DIR__, 2);
+        $projectRoot = getenv('CLAUDRIEL_PROJECT_ROOT') ?: dirname(__DIR__, 2);
 
         // Load recent events.
         $eventStorage = $this->entityTypeManager->getStorage('mc_event');

--- a/src/Controller/DayBriefController.php
+++ b/src/Controller/DayBriefController.php
@@ -23,7 +23,7 @@ final class DayBriefController
 
     public function show(array $params = [], array $query = [], mixed $account = null, mixed $httpRequest = null): SsrResponse
     {
-        $storageDir   = getenv('MYCLAUDIA_STORAGE') ?: sys_get_temp_dir() . '/myclaudia';
+        $storageDir   = getenv('CLAUDRIEL_STORAGE') ?: sys_get_temp_dir() . '/myclaudia';
         $sessionStore = new BriefSessionStore($storageDir . '/brief-session.txt');
         $since        = $sessionStore->getLastBriefAt() ?? new \DateTimeImmutable('-24 hours');
 

--- a/src/Controller/IngestController.php
+++ b/src/Controller/IngestController.php
@@ -84,8 +84,8 @@ final class IngestController
      */
     private function getValidApiKeys(): array
     {
-        $key = $_ENV['MYCLAUDIA_API_KEY']
-            ?? getenv('MYCLAUDIA_API_KEY')
+        $key = $_ENV['CLAUDRIEL_API_KEY']
+            ?? getenv('CLAUDRIEL_API_KEY')
             ?: null;
 
         if ($key === null || $key === '' || $key === false) {

--- a/tests/Unit/Controller/IngestControllerTest.php
+++ b/tests/Unit/Controller/IngestControllerTest.php
@@ -25,7 +25,7 @@ final class IngestControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->originalApiKey = $_ENV['MYCLAUDIA_API_KEY'] ?? '';
+        $this->originalApiKey = $_ENV['CLAUDRIEL_API_KEY'] ?? '';
 
         $db = PdoDatabase::createSqlite(':memory:');
         $dispatcher = new EventDispatcher();
@@ -42,7 +42,7 @@ final class IngestControllerTest extends TestCase
             $this->entityTypeManager->registerEntityType($type);
         }
 
-        $_ENV['MYCLAUDIA_API_KEY'] = 'test-secret-key';
+        $_ENV['CLAUDRIEL_API_KEY'] = 'test-secret-key';
 
         $this->controller = new IngestController($this->entityTypeManager);
     }
@@ -50,9 +50,9 @@ final class IngestControllerTest extends TestCase
     protected function tearDown(): void
     {
         if ($this->originalApiKey !== '') {
-            $_ENV['MYCLAUDIA_API_KEY'] = $this->originalApiKey;
+            $_ENV['CLAUDRIEL_API_KEY'] = $this->originalApiKey;
         } else {
-            unset($_ENV['MYCLAUDIA_API_KEY']);
+            unset($_ENV['CLAUDRIEL_API_KEY']);
         }
     }
 

--- a/tools/memory-mcp/server.js
+++ b/tools/memory-mcp/server.js
@@ -6,8 +6,8 @@
  * can read/write the dashboard's entity storage as their memory backend.
  *
  * Required env vars:
- *   MYCLAUDIA_API_URL  — e.g. http://localhost:8088
- *   MYCLAUDIA_API_KEY  — bearer token for /api/ingest
+ *   CLAUDRIEL_API_URL  — e.g. http://localhost:8088
+ *   CLAUDRIEL_API_KEY  — bearer token for /api/ingest
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -15,8 +15,8 @@ import { z } from 'zod';
 import fs from 'fs';
 import path from 'path';
 
-const API_URL = process.env.MYCLAUDIA_API_URL || 'http://localhost:8088';
-const API_KEY = process.env.MYCLAUDIA_API_KEY || '';
+const API_URL = process.env.CLAUDRIEL_API_URL || 'http://localhost:8088';
+const API_KEY = process.env.CLAUDRIEL_API_KEY || '';
 
 // Resolve project root (two levels up from tools/memory-mcp/)
 const PROJECT_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');


### PR DESCRIPTION
## Summary
- Renames CLI commands: `myclaudia:brief` → `claudriel:brief`, `myclaudia:commitments` → `claudriel:commitments`, etc.
- Renames env vars: `MYCLAUDIA_API_KEY` → `CLAUDRIEL_API_KEY`, `MYCLAUDIA_API_URL` → `CLAUDRIEL_API_URL`, `MYCLAUDIA_ROOT` → `CLAUDRIEL_ROOT`
- Updates .env.example, bin/mc-ingest, MCP server config, settings.json

## Test plan
- [x] All 72 tests pass

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)