### PR TITLE
refactor(#53): rename deploy scripts and CI paths to claudriel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout myclaudia
+      - name: Checkout claudriel
         uses: actions/checkout@v4
         with:
-          path: myclaudia
+          path: claudriel
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -23,21 +23,21 @@ jobs:
           coverage: none
 
       - name: Validate composer.json
-        working-directory: myclaudia
+        working-directory: claudriel
         run: composer validate --no-check-publish
 
       - name: Check PHP syntax
-        working-directory: myclaudia
+        working-directory: claudriel
         run: find src -name '*.php' -print0 | xargs -0 -n1 php -l
 
   test:
     name: PHPUnit
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout myclaudia
+      - name: Checkout claudriel
         uses: actions/checkout@v4
         with:
-          path: myclaudia
+          path: claudriel
 
       - name: Checkout waaseyaa framework
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
           coverage: none
 
       - name: Rewrite Composer path repositories for CI
-        working-directory: myclaudia
+        working-directory: claudriel
         run: |
           php -r "
             \$c = json_decode(file_get_contents('composer.json'), true);
@@ -63,9 +63,9 @@ jobs:
           rm -f composer.lock
 
       - name: Install dependencies
-        working-directory: myclaudia
+        working-directory: claudriel
         run: composer install --no-interaction --prefer-dist
 
       - name: Run unit tests
-        working-directory: myclaudia
+        working-directory: claudriel
         run: ./vendor/bin/phpunit

--- a/bin/deploy
+++ b/bin/deploy
@@ -39,4 +39,4 @@ git checkout main
 echo "✓ Back on main"
 echo ""
 echo "To update installed copy:"
-echo "  cd ~/myclaudia && git pull"
+echo "  cd ~/claudriel && git pull"

--- a/bin/setup-install
+++ b/bin/setup-install
@@ -3,9 +3,9 @@ set -euo pipefail
 
 # Setup: clone repo and configure as installed copy
 # Usage: bin/setup-install [target-dir]
-# Default target: ~/myclaudia
+# Default target: ~/claudriel
 
-TARGET="${1:-$HOME/myclaudia}"
+TARGET="${1:-$HOME/claudriel}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
@@ -14,7 +14,7 @@ if [ -d "$TARGET" ]; then
     exit 1
 fi
 
-echo "Setting up MyClaudia at $TARGET..."
+echo "Setting up Claudriel at $TARGET..."
 
 # Clone and checkout release
 git clone "$REPO_DIR" "$TARGET"
@@ -39,7 +39,7 @@ else
 fi
 
 echo ""
-echo "✓ MyClaudia installed at $TARGET"
+echo "✓ Claudriel installed at $TARGET"
 echo ""
 echo "Next steps:"
 echo "  1. Copy user data from old installation:"


### PR DESCRIPTION
## Summary
- `bin/deploy`: references `~/claudriel` instead of `~/myclaudia`
- `bin/setup-install`: default target `~/claudriel`, updated messages
- `.github/workflows/ci.yml`: checkout/working-directory paths renamed

## Post-merge manual steps
1. `gh repo rename claudriel`
2. `mv ~/dev/myclaudia ~/dev/claudriel`
3. `mv ~/myclaudia ~/claudriel`
4. Update git remotes in both copies
5. Update MEMORY.md project paths

## Test plan
- [x] Scripts have correct paths
- [x] CI workflow YAML is valid

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)