### PR TITLE
feat(#67,#69): add content_hash and category to McEvent

### DIFF
--- a/src/Entity/McEvent.php
+++ b/src/Entity/McEvent.php
@@ -15,12 +15,25 @@ final class McEvent extends ContentEntityBase
     protected string $entityTypeId = 'mc_event';
 
     protected array $entityKeys = [
-        'id'   => 'eid',
-        'uuid' => 'uuid',
+        'id'           => 'eid',
+        'uuid'         => 'uuid',
+        'content_hash' => 'content_hash',
     ];
 
     public function __construct(array $values = [])
     {
         parent::__construct($values, 'mc_event', $this->entityKeys);
+
+        if ($this->get('category') === null) {
+            $this->set('category', 'notification');
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getEntityKeys(): array
+    {
+        return $this->entityKeys;
     }
 }

--- a/tests/Unit/Entity/McEventTest.php
+++ b/tests/Unit/Entity/McEventTest.php
@@ -21,4 +21,25 @@ final class McEventTest extends TestCase
         self::assertSame('gmail', $event->get('source'));
         self::assertSame('message.received', $event->get('type'));
     }
+
+    public function test_entity_keys_include_content_hash(): void
+    {
+        $event = new McEvent();
+        $keys = $event->getEntityKeys();
+        $this->assertArrayHasKey('content_hash', $keys);
+        $this->assertSame('content_hash', $keys['content_hash']);
+    }
+
+    public function test_category_defaults_to_notification(): void
+    {
+        $event = new McEvent();
+        $this->assertSame('notification', $event->get('category'));
+    }
+
+    public function test_category_can_be_set(): void
+    {
+        $event = new McEvent();
+        $event->set('category', 'job_hunt');
+        $this->assertSame('job_hunt', $event->get('category'));
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `content_hash` to McEvent entityKeys for event deduplication (#67)
- Adds `category` field with `notification` default for event categorization (#69)
- Adds `getEntityKeys()` accessor method to McEvent

## Test plan
- [x] Unit test: entityKeys includes content_hash
- [x] Unit test: category defaults to notification
- [x] Unit test: category can be set to other values
- [x] Full test suite passes (94 tests, 235 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)