### PR TITLE
feat(#67): create ContentHasher utility

### DIFF
--- a/src/Support/ContentHasher.php
+++ b/src/Support/ContentHasher.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Support;
+
+final class ContentHasher
+{
+    public static function hash(array $payload): string
+    {
+        $source = $payload['source'] ?? '';
+
+        return match ($source) {
+            'google-calendar' => self::hashCalendar($payload),
+            'gmail' => self::hashGmail($payload),
+            default => self::hashGeneric($payload),
+        };
+    }
+
+    private static function hashCalendar(array $payload): string
+    {
+        return hash('sha256', implode('|', [
+            $payload['title'] ?? '',
+            $payload['start_time'] ?? '',
+            $payload['calendar_id'] ?? '',
+        ]));
+    }
+
+    private static function hashGmail(array $payload): string
+    {
+        return hash('sha256', $payload['message_id'] ?? '');
+    }
+
+    private static function hashGeneric(array $payload): string
+    {
+        return hash('sha256', implode('|', [
+            $payload['source'] ?? '',
+            $payload['type'] ?? '',
+            $payload['body'] ?? '',
+        ]));
+    }
+}

--- a/tests/Unit/Support/ContentHasherTest.php
+++ b/tests/Unit/Support/ContentHasherTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Support;
+
+use Claudriel\Support\ContentHasher;
+use PHPUnit\Framework\TestCase;
+
+final class ContentHasherTest extends TestCase
+{
+    public function test_hashes_calendar_event_by_title_start_time_calendar_id(): void
+    {
+        $payload = [
+            'source' => 'google-calendar',
+            'title' => 'Job Applications',
+            'start_time' => '2026-03-10T08:00:00',
+            'calendar_id' => 'primary',
+        ];
+        $hash = ContentHasher::hash($payload);
+        $this->assertSame(64, strlen($hash));
+        $this->assertSame($hash, ContentHasher::hash($payload));
+    }
+
+    public function test_hashes_gmail_message_by_message_id(): void
+    {
+        $payload = [
+            'source' => 'gmail',
+            'message_id' => 'msg-abc-123',
+        ];
+        $hash = ContentHasher::hash($payload);
+        $this->assertSame(64, strlen($hash));
+        $this->assertSame($hash, ContentHasher::hash($payload));
+    }
+
+    public function test_hashes_generic_source_by_source_type_body(): void
+    {
+        $payload = [
+            'source' => 'webhook',
+            'type' => 'notification',
+            'body' => 'Hello world',
+        ];
+        $hash = ContentHasher::hash($payload);
+        $this->assertSame(64, strlen($hash));
+        $this->assertSame($hash, ContentHasher::hash($payload));
+    }
+
+    public function test_different_sources_produce_different_hashes(): void
+    {
+        $gmail = ContentHasher::hash(['source' => 'gmail', 'message_id' => 'abc']);
+        $calendar = ContentHasher::hash(['source' => 'google-calendar', 'title' => 'abc', 'start_time' => '', 'calendar_id' => '']);
+        $this->assertNotSame($gmail, $calendar);
+    }
+
+    public function test_empty_payload_does_not_throw(): void
+    {
+        $hash = ContentHasher::hash([]);
+        $this->assertSame(64, strlen($hash));
+    }
+}


### PR DESCRIPTION
## Summary
- New static utility `ContentHasher` for computing SHA-256 dedup hashes
- Source-aware hashing: calendar (title+start+cal_id), gmail (message_id), generic (source+type+body)
- 5 unit tests covering all source types, cross-source uniqueness, and empty payload safety

## Test plan
- [x] Calendar events hashed by title+start_time+calendar_id
- [x] Gmail messages hashed by message_id
- [x] Generic sources hashed by source+type+body
- [x] Different sources produce different hashes
- [x] Empty payload doesn't throw
- [x] Full test suite passes (96 tests, 239 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)