### PR TITLE
feat(#68): person tier system

### DIFF
--- a/src/Command/MigratePersonTiersCommand.php
+++ b/src/Command/MigratePersonTiersCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Command;
+
+use Claudriel\Support\PersonTierClassifier;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+
+#[AsCommand(name: 'claudriel:migrate-person-tiers', description: 'Backfill tier field on existing Person entities')]
+final class MigratePersonTiersCommand extends Command
+{
+    public function __construct(private readonly EntityRepositoryInterface $personRepo)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $persons = $this->personRepo->findBy([]);
+        $updated = 0;
+
+        foreach ($persons as $person) {
+            $email = $person->get('email') ?? '';
+            $tier = PersonTierClassifier::classify($email, $person->get('name'));
+
+            if ($person->get('tier') !== $tier) {
+                $person->set('tier', $tier);
+                $this->personRepo->save($person);
+                $updated++;
+            }
+        }
+
+        $output->writeln(sprintf('Updated %d person(s).', $updated));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Entity/Person.php
+++ b/src/Entity/Person.php
@@ -19,5 +19,9 @@ final class Person extends ContentEntityBase
     public function __construct(array $values = [])
     {
         parent::__construct($values, 'person', $this->entityKeys);
+
+        if ($this->get('tier') === null) {
+            $this->set('tier', 'contact');
+        }
     }
 }

--- a/src/Support/PersonTierClassifier.php
+++ b/src/Support/PersonTierClassifier.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Support;
+
+final class PersonTierClassifier
+{
+    private const AUTOMATED_PATTERNS = [
+        'noreply@', 'no-reply@', 'notifications@', 'mailer-daemon@',
+        'donotreply@', 'automated@', 'system@', 'alerts@',
+    ];
+
+    public static function classify(string $email, ?string $name = null): string
+    {
+        $lower = strtolower($email);
+
+        foreach (self::AUTOMATED_PATTERNS as $pattern) {
+            if (str_contains($lower, $pattern)) {
+                return 'automated';
+            }
+        }
+
+        return 'contact';
+    }
+}

--- a/tests/Unit/Command/MigratePersonTiersCommandTest.php
+++ b/tests/Unit/Command/MigratePersonTiersCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Command;
+
+use Claudriel\Command\MigratePersonTiersCommand;
+use Claudriel\Entity\Person;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+
+final class MigratePersonTiersCommandTest extends TestCase
+{
+    public function test_updates_person_tiers(): void
+    {
+        $person1 = new Person(['email' => 'jane@example.com', 'name' => 'Jane', 'tier' => 'contact']);
+        $person2 = new Person(['email' => 'noreply@github.com', 'name' => 'GitHub', 'tier' => 'contact']);
+
+        $repo = $this->createMock(EntityRepositoryInterface::class);
+        $repo->method('findBy')->willReturn([$person1, $person2]);
+        $repo->expects($this->once())->method('save')->with($person2);
+
+        $command = new MigratePersonTiersCommand($repo);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Updated 1 person(s)', $tester->getDisplay());
+    }
+
+    public function test_no_updates_when_tiers_correct(): void
+    {
+        $repo = $this->createMock(EntityRepositoryInterface::class);
+        $repo->method('findBy')->willReturn([]);
+        $repo->expects($this->never())->method('save');
+
+        $command = new MigratePersonTiersCommand($repo);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertStringContainsString('Updated 0 person(s)', $tester->getDisplay());
+    }
+}

--- a/tests/Unit/Entity/PersonTest.php
+++ b/tests/Unit/Entity/PersonTest.php
@@ -14,4 +14,17 @@ final class PersonTest extends TestCase
         $person = new Person(['email' => 'jane@example.com', 'name' => 'Jane']);
         self::assertSame('person', $person->getEntityTypeId());
     }
+
+    public function test_tier_defaults_to_contact(): void
+    {
+        $person = new Person();
+        $this->assertSame('contact', $person->get('tier'));
+    }
+
+    public function test_tier_can_be_set(): void
+    {
+        $person = new Person();
+        $person->set('tier', 'creator');
+        $this->assertSame('creator', $person->get('tier'));
+    }
 }

--- a/tests/Unit/Support/PersonTierClassifierTest.php
+++ b/tests/Unit/Support/PersonTierClassifierTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Support;
+
+use Claudriel\Support\PersonTierClassifier;
+use PHPUnit\Framework\TestCase;
+
+final class PersonTierClassifierTest extends TestCase
+{
+    public function test_classifies_noreply_as_automated(): void
+    {
+        $this->assertSame('automated', PersonTierClassifier::classify('noreply@example.com'));
+    }
+
+    public function test_classifies_notifications_as_automated(): void
+    {
+        $this->assertSame('automated', PersonTierClassifier::classify('notifications@github.com'));
+    }
+
+    public function test_classifies_regular_email_as_contact(): void
+    {
+        $this->assertSame('contact', PersonTierClassifier::classify('jane@example.com'));
+    }
+
+    public function test_classification_is_case_insensitive(): void
+    {
+        $this->assertSame('automated', PersonTierClassifier::classify('NoReply@Example.COM'));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `tier` field to Person entity with `contact` default
- New `PersonTierClassifier` utility: classifies emails as `automated` (noreply, notifications, etc.) or `contact`
- New `claudriel:migrate-person-tiers` CLI command for backfilling existing Person records

## Test plan
- [x] Person tier defaults to contact
- [x] Person tier can be set
- [x] Classifier: noreply → automated
- [x] Classifier: notifications → automated
- [x] Classifier: regular email → contact
- [x] Classifier: case insensitive
- [x] Migration command updates incorrect tiers
- [x] Migration command handles empty dataset
- [x] Full test suite passes (99 tests, 242 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)