### PR TITLE
feat(#69): create EventCategorizer utility

### DIFF
--- a/src/Ingestion/EventCategorizer.php
+++ b/src/Ingestion/EventCategorizer.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Ingestion;
+
+final class EventCategorizer
+{
+    private const JOB_KEYWORDS = [
+        'application', 'interview', 'job', 'position', 'hiring',
+        'recruiter', 'resume', 'offer', 'salary', 'applied',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function categorize(string $source, string $type, array $payload = []): string
+    {
+        if ($source === 'google-calendar') {
+            return self::categorizeCalendar($payload);
+        }
+
+        if ($source === 'gmail') {
+            return self::categorizeGmail($type, $payload);
+        }
+
+        return 'notification';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private static function categorizeCalendar(array $payload): string
+    {
+        $title = strtolower($payload['title'] ?? '');
+        foreach (self::JOB_KEYWORDS as $keyword) {
+            if (str_contains($title, $keyword)) {
+                return 'job_hunt';
+            }
+        }
+
+        return 'schedule';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private static function categorizeGmail(string $type, array $payload): string
+    {
+        $subject = strtolower($payload['subject'] ?? '');
+        $body = strtolower($payload['body'] ?? '');
+        $combined = $subject . ' ' . $body;
+
+        foreach (self::JOB_KEYWORDS as $keyword) {
+            if (str_contains($combined, $keyword)) {
+                return 'job_hunt';
+            }
+        }
+
+        return 'people';
+    }
+}

--- a/tests/Unit/Ingestion/EventCategorizerTest.php
+++ b/tests/Unit/Ingestion/EventCategorizerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Ingestion;
+
+use Claudriel\Ingestion\EventCategorizer;
+use PHPUnit\Framework\TestCase;
+
+final class EventCategorizerTest extends TestCase
+{
+    public function test_calendar_event_categorized_as_schedule(): void
+    {
+        $result = EventCategorizer::categorize('google-calendar', 'calendar.event', ['title' => 'Team standup']);
+        $this->assertSame('schedule', $result);
+    }
+
+    public function test_calendar_event_with_job_keyword_categorized_as_job_hunt(): void
+    {
+        $result = EventCategorizer::categorize('google-calendar', 'calendar.event', ['title' => 'Interview with Acme Corp']);
+        $this->assertSame('job_hunt', $result);
+    }
+
+    public function test_gmail_with_job_subject_categorized_as_job_hunt(): void
+    {
+        $result = EventCategorizer::categorize('gmail', 'message.received', ['subject' => 'Your application was received']);
+        $this->assertSame('job_hunt', $result);
+    }
+
+    public function test_gmail_with_job_body_categorized_as_job_hunt(): void
+    {
+        $result = EventCategorizer::categorize('gmail', 'message.received', ['subject' => 'Hello', 'body' => 'We have a position for you']);
+        $this->assertSame('job_hunt', $result);
+    }
+
+    public function test_gmail_without_job_keywords_categorized_as_people(): void
+    {
+        $result = EventCategorizer::categorize('gmail', 'message.received', ['subject' => 'Lunch tomorrow?', 'body' => 'Want to grab lunch?']);
+        $this->assertSame('people', $result);
+    }
+
+    public function test_unknown_source_categorized_as_notification(): void
+    {
+        $result = EventCategorizer::categorize('webhook', 'alert', []);
+        $this->assertSame('notification', $result);
+    }
+
+    public function test_categorization_is_case_insensitive(): void
+    {
+        $result = EventCategorizer::categorize('gmail', 'message.received', ['subject' => 'JOB APPLICATION Update']);
+        $this->assertSame('job_hunt', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- New `EventCategorizer` static utility for classifying events into categories
- Calendar events → `schedule` (or `job_hunt` if title contains job keywords)
- Gmail → `job_hunt` (if subject/body matches) or `people`
- Unknown sources → `notification`

## Test plan
- [x] Calendar → schedule
- [x] Calendar with job keyword → job_hunt
- [x] Gmail with job subject → job_hunt
- [x] Gmail with job body → job_hunt
- [x] Gmail without job keywords → people
- [x] Unknown source → notification
- [x] Case insensitive
- [x] Full test suite passes (98 tests, 238 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)