### PR TITLE
feat(#69): create ActionabilityStep pipeline step

### DIFF
--- a/src/Pipeline/ActionabilityStep.php
+++ b/src/Pipeline/ActionabilityStep.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Pipeline;
+
+use Waaseyaa\AI\Pipeline\PipelineContext;
+use Waaseyaa\AI\Pipeline\PipelineStepInterface;
+use Waaseyaa\AI\Pipeline\StepResult;
+
+final class ActionabilityStep implements PipelineStepInterface
+{
+    private const KEYWORDS = [
+        'deadline', 'due', 'rsvp', 'confirm', 'action required',
+        'respond', 'review', 'approve', 'submit', 'expires', 'urgent',
+    ];
+
+    public function process(array $input, PipelineContext $context): StepResult
+    {
+        $text = strtolower(
+            ($input['subject'] ?? '') . ' ' . ($input['body'] ?? '')
+        );
+
+        $matched = [];
+        foreach (self::KEYWORDS as $keyword) {
+            if (str_contains($text, $keyword)) {
+                $matched[] = $keyword;
+            }
+        }
+
+        return StepResult::success([
+            'is_actionable' => $matched !== [],
+            'matched_keywords' => $matched,
+        ]);
+    }
+
+    public function describe(): string
+    {
+        return 'Detect actionability via keyword matching on event text.';
+    }
+}

--- a/tests/Unit/Pipeline/ActionabilityStepTest.php
+++ b/tests/Unit/Pipeline/ActionabilityStepTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Pipeline;
+
+use Claudriel\Pipeline\ActionabilityStep;
+use PHPUnit\Framework\TestCase;
+use Waaseyaa\AI\Pipeline\PipelineContext;
+
+final class ActionabilityStepTest extends TestCase
+{
+    private ActionabilityStep $step;
+
+    private PipelineContext $context;
+
+    protected function setUp(): void
+    {
+        $this->step = new ActionabilityStep();
+        $this->context = new PipelineContext(pipelineId: 'test', startedAt: time());
+    }
+
+    public function test_detects_deadline_keyword(): void
+    {
+        $result = $this->step->process(['subject' => 'Project deadline tomorrow', 'body' => ''], $this->context);
+        self::assertTrue($result->output['is_actionable']);
+        self::assertContains('deadline', $result->output['matched_keywords']);
+    }
+
+    public function test_detects_action_required_in_body(): void
+    {
+        $result = $this->step->process(['subject' => 'Update', 'body' => 'Action required: please review'], $this->context);
+        self::assertTrue($result->output['is_actionable']);
+        self::assertContains('action required', $result->output['matched_keywords']);
+        self::assertContains('review', $result->output['matched_keywords']);
+    }
+
+    public function test_non_actionable_text(): void
+    {
+        $result = $this->step->process(['subject' => 'Newsletter', 'body' => 'Here are this weeks updates'], $this->context);
+        self::assertFalse($result->output['is_actionable']);
+        self::assertEmpty($result->output['matched_keywords']);
+    }
+
+    public function test_case_insensitive_matching(): void
+    {
+        $result = $this->step->process(['subject' => 'URGENT: Review needed', 'body' => ''], $this->context);
+        self::assertTrue($result->output['is_actionable']);
+        self::assertContains('urgent', $result->output['matched_keywords']);
+        self::assertContains('review', $result->output['matched_keywords']);
+    }
+
+    public function test_empty_input(): void
+    {
+        $result = $this->step->process([], $this->context);
+        self::assertFalse($result->output['is_actionable']);
+        self::assertEmpty($result->output['matched_keywords']);
+    }
+
+    public function test_describe(): void
+    {
+        self::assertNotEmpty($this->step->describe());
+    }
+}


### PR DESCRIPTION
## Summary
- New `ActionabilityStep` implementing `PipelineStepInterface` for keyword-based actionability detection
- Scans subject+body for actionable keywords (deadline, urgent, rsvp, confirm, etc.)
- Returns `is_actionable` boolean and `matched_keywords` array

## Test plan
- [x] Detects deadline keyword
- [x] Detects action required + review in body
- [x] Non-actionable text returns false
- [x] Case insensitive matching
- [x] Empty input handled gracefully
- [x] describe() returns non-empty string
- [x] Full test suite passes (97 tests, 244 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)