### PR TITLE
fix(#84): wire EventCategorizer into GenericEventHandler

### DIFF
--- a/bin/fix-event-categories.php
+++ b/bin/fix-event-categories.php
@@ -1,0 +1,77 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * One-time migration: re-categorize existing mc_event rows using EventCategorizer logic.
+ *
+ * Usage: php bin/fix-event-categories.php [path/to/waaseyaa.sqlite]
+ */
+$dbPath = $argv[1] ?? dirname(__DIR__).'/waaseyaa.sqlite';
+
+if (! file_exists($dbPath)) {
+    fwrite(STDERR, "Database not found: {$dbPath}\n");
+    exit(1);
+}
+
+$pdo = new PDO("sqlite:{$dbPath}", null, null, [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+]);
+
+// Inline categorization logic matching EventCategorizer
+$jobKeywords = ['application', 'interview', 'job', 'position', 'hiring', 'recruiter', 'resume', 'offer', 'salary', 'applied'];
+
+function categorize(string $source, string $type, array $payload, array $jobKeywords): string
+{
+    if ($source === 'google-calendar') {
+        $title = strtolower($payload['title'] ?? $payload['subject'] ?? '');
+        foreach ($jobKeywords as $keyword) {
+            if (str_contains($title, $keyword)) {
+                return 'job_hunt';
+            }
+        }
+
+        return 'schedule';
+    }
+
+    if ($source === 'gmail') {
+        $subject = strtolower($payload['subject'] ?? '');
+        $body = strtolower($payload['body'] ?? '');
+        $combined = $subject.' '.$body;
+        foreach ($jobKeywords as $keyword) {
+            if (str_contains($combined, $keyword)) {
+                return 'job_hunt';
+            }
+        }
+
+        return 'people';
+    }
+
+    return 'notification';
+}
+
+$rows = $pdo->query('SELECT eid, _data FROM mc_event')->fetchAll(PDO::FETCH_ASSOC);
+$updated = 0;
+
+foreach ($rows as $row) {
+    $data = json_decode($row['_data'], true) ?? [];
+    $source = $data['source'] ?? '';
+    $type = $data['type'] ?? '';
+    $payloadJson = $data['payload'] ?? '{}';
+    $payload = is_string($payloadJson) ? (json_decode($payloadJson, true) ?? []) : $payloadJson;
+
+    $newCategory = categorize($source, $type, $payload, $jobKeywords);
+    $oldCategory = $data['category'] ?? 'notification';
+
+    if ($newCategory !== $oldCategory) {
+        $data['category'] = $newCategory;
+        $newData = json_encode($data, JSON_THROW_ON_ERROR);
+        $stmt = $pdo->prepare('UPDATE mc_event SET _data = ? WHERE eid = ?');
+        $stmt->execute([$newData, $row['eid']]);
+        $updated++;
+
+        $title = $payload['subject'] ?? $payload['title'] ?? 'no title';
+        echo "  {$type}: {$oldCategory} -> {$newCategory} ({$title})\n";
+    }
+}
+
+echo "Re-categorized {$updated} of ".count($rows)." events.\n";

--- a/src/Command/RecategorizeEventsCommand.php
+++ b/src/Command/RecategorizeEventsCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Command;
+
+use Claudriel\Ingestion\EventCategorizer;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Waaseyaa\Entity\EntityTypeManagerInterface;
+
+#[AsCommand(name: 'claudriel:recategorize-events', description: 'Re-categorize existing events using EventCategorizer')]
+final class RecategorizeEventsCommand extends Command
+{
+    public function __construct(
+        private readonly EntityTypeManagerInterface $entityTypeManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $storage = $this->entityTypeManager->getStorage('mc_event');
+        $ids = $storage->getQuery()->execute();
+        $events = $storage->loadMultiple($ids);
+
+        $updated = 0;
+        foreach ($events as $event) {
+            $source = $event->get('source') ?? '';
+            $type = $event->get('type') ?? '';
+            $payloadJson = $event->get('payload') ?? '{}';
+            $payload = json_decode($payloadJson, true) ?? [];
+
+            $newCategory = EventCategorizer::categorize($source, $type, $payload);
+            $oldCategory = $event->get('category') ?? 'notification';
+
+            if ($newCategory !== $oldCategory) {
+                $event->set('category', $newCategory);
+                $storage->save($event);
+                $updated++;
+                $output->writeln(sprintf(
+                    '  %s: %s -> %s (%s)',
+                    $event->get('type') ?? 'unknown',
+                    $oldCategory,
+                    $newCategory,
+                    $payload['subject'] ?? $payload['title'] ?? 'no title',
+                ));
+            }
+        }
+
+        $output->writeln(sprintf('<info>Re-categorized %d of %d events.</info>', $updated, count($events)));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/ChatStreamController.php
+++ b/src/Controller/ChatStreamController.php
@@ -204,7 +204,13 @@ final class ChatStreamController
         $skillRepo = new StorageRepositoryAdapter($skillStorage);
         $driftDetector = new DriftDetector($commitmentRepo);
 
-        $assembler = new DayBriefAssembler($eventRepo, $commitmentRepo, $driftDetector, $skillRepo);
+        $personRepo = null;
+        try {
+            $personRepo = new StorageRepositoryAdapter($this->entityTypeManager->getStorage('person'));
+        } catch (\Throwable) {
+        }
+
+        $assembler = new DayBriefAssembler($eventRepo, $commitmentRepo, $driftDetector, $personRepo, $skillRepo);
 
         return new ChatSystemPromptBuilder($assembler, $projectRoot);
     }

--- a/src/Ingestion/EventCategorizer.php
+++ b/src/Ingestion/EventCategorizer.php
@@ -32,7 +32,7 @@ final class EventCategorizer
      */
     private static function categorizeCalendar(array $payload): string
     {
-        $title = strtolower($payload['title'] ?? '');
+        $title = strtolower($payload['title'] ?? $payload['subject'] ?? '');
         foreach (self::JOB_KEYWORDS as $keyword) {
             if (str_contains($title, $keyword)) {
                 return 'job_hunt';

--- a/src/Ingestion/Handler/GenericEventHandler.php
+++ b/src/Ingestion/Handler/GenericEventHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Claudriel\Ingestion\Handler;
 
 use Claudriel\Entity\McEvent;
+use Claudriel\Ingestion\EventCategorizer;
 use Claudriel\Ingestion\IngestHandlerInterface;
 use Waaseyaa\Entity\EntityTypeManagerInterface;
 
@@ -26,11 +27,15 @@ final class GenericEventHandler implements IngestHandlerInterface
 
     public function handle(array $data): array
     {
+        $payload = $data['payload'];
+        $category = EventCategorizer::categorize($data['source'], $data['type'], $payload);
+
         $event = new McEvent([
             'source' => $data['source'],
             'type' => $data['type'],
-            'payload' => json_encode($data['payload'], JSON_THROW_ON_ERROR),
+            'payload' => json_encode($payload, JSON_THROW_ON_ERROR),
             'occurred' => date('Y-m-d H:i:s'),
+            'category' => $category,
         ]);
 
         $storage = $this->entityTypeManager->getStorage('mc_event');

--- a/src/Provider/ClaudrielServiceProvider.php
+++ b/src/Provider/ClaudrielServiceProvider.php
@@ -7,6 +7,7 @@ namespace Claudriel\Provider;
 use Claudriel\Command\BriefCommand;
 use Claudriel\Command\CommitmentsCommand;
 use Claudriel\Command\CommitmentUpdateCommand;
+use Claudriel\Command\RecategorizeEventsCommand;
 use Claudriel\Command\SkillsCommand;
 use Claudriel\Command\WorkspaceCreateCommand;
 use Claudriel\Command\WorkspacesCommand;
@@ -323,6 +324,7 @@ final class ClaudrielServiceProvider extends ServiceProvider
             new SkillsCommand($skillRepo),
             new WorkspacesCommand($workspaceRepo),
             new WorkspaceCreateCommand($workspaceRepo),
+            new RecategorizeEventsCommand($entityTypeManager),
         ];
     }
 }


### PR DESCRIPTION
## Summary

- Wire `EventCategorizer::categorize()` into `GenericEventHandler` so ingested events get proper categories (schedule, people, job_hunt) instead of all defaulting to 'notification'
- Fix `ChatStreamController` passing `$skillRepo` in the `$personRepo` position of `DayBriefAssembler` constructor
- Add `subject` fallback in `EventCategorizer::categorizeCalendar()` for payloads using `subject` instead of `title`
- Add `RecategorizeEventsCommand` CLI command and standalone migration script for existing data

## Test plan

- [x] All 151 tests pass
- [x] Pint lint clean
- [x] Migration script tested against copy of prod DB (38/39 events re-categorized)
- [x] Migration script run against local prod DB successfully
- [ ] Deploy and run `php bin/fix-event-categories.php` on production
- [ ] Verify dashboard sidebar shows populated Schedule, People, and Job Hunt sections

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)