### PR TITLE
Fix session-backed app shell authentication

### DIFF
--- a/src/Controller/AppShellController.php
+++ b/src/Controller/AppShellController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Claudriel\Controller;
 
 use Claudriel\Access\AuthenticatedAccount;
+use Claudriel\Support\AuthenticatedAccountSessionResolver;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Twig\Environment;
 use Waaseyaa\Entity\EntityTypeManager;
@@ -19,11 +20,15 @@ final class AppShellController
 
     public function show(array $params = [], array $query = [], mixed $account = null, mixed $httpRequest = null): RedirectResponse|SsrResponse
     {
-        if (! $account instanceof AuthenticatedAccount) {
+        $resolvedAccount = $account instanceof AuthenticatedAccount
+            ? $account
+            : (new AuthenticatedAccountSessionResolver($this->entityTypeManager))->resolve();
+
+        if (! $resolvedAccount instanceof AuthenticatedAccount) {
             return new RedirectResponse('/login', 302);
         }
 
         return (new DashboardController($this->entityTypeManager, $this->twig))
-            ->show($params, $query, $account, $httpRequest);
+            ->show($params, $query, $resolvedAccount, $httpRequest);
     }
 }

--- a/src/Controller/PublicAccountController.php
+++ b/src/Controller/PublicAccountController.php
@@ -12,6 +12,7 @@ use Claudriel\Service\PublicAccountSignupService;
 use Claudriel\Service\SidecarWorkspaceBootstrapService;
 use Claudriel\Service\TenantBootstrapService;
 use Claudriel\Service\WorkspaceBootstrapService;
+use Claudriel\Support\AuthenticatedAccountSessionResolver;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
@@ -32,8 +33,12 @@ final class PublicAccountController
 
     public function signupForm(array $params = [], array $query = [], mixed $account = null): RedirectResponse|SsrResponse
     {
-        if ($account instanceof AuthenticatedAccount) {
-            return new RedirectResponse($this->appUrl((string) $account->getTenantId()), 302);
+        $resolvedAccount = $account instanceof AuthenticatedAccount
+            ? $account
+            : (new AuthenticatedAccountSessionResolver($this->entityTypeManager))->resolve();
+
+        if ($resolvedAccount instanceof AuthenticatedAccount) {
+            return new RedirectResponse($this->appUrl((string) $resolvedAccount->getTenantId()), 302);
         }
 
         return $this->render('public/signup.twig', [

--- a/src/Controller/PublicSessionController.php
+++ b/src/Controller/PublicSessionController.php
@@ -7,6 +7,7 @@ namespace Claudriel\Controller;
 use Claudriel\Access\AuthenticatedAccount;
 use Claudriel\Entity\Account;
 use Claudriel\Entity\Tenant;
+use Claudriel\Support\AuthenticatedAccountSessionResolver;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
@@ -93,7 +94,11 @@ final class PublicSessionController
 
     public function sessionState(array $params = [], array $query = [], mixed $account = null): SsrResponse
     {
-        if (! $account instanceof AuthenticatedAccount) {
+        $resolvedAccount = $account instanceof AuthenticatedAccount
+            ? $account
+            : $this->authenticatedAccountFromSession();
+
+        if (! $resolvedAccount instanceof AuthenticatedAccount) {
             return new SsrResponse(
                 content: json_encode(['error' => 'Not authenticated.'], JSON_THROW_ON_ERROR),
                 statusCode: 401,
@@ -104,11 +109,11 @@ final class PublicSessionController
         return new SsrResponse(
             content: json_encode([
                 'account' => [
-                    'uuid' => $account->getUuid(),
-                    'email' => $account->getEmail(),
-                    'tenant_id' => $account->getTenantId(),
-                    'roles' => $account->getRoles(),
-                    'default_workspace_uuid' => $this->defaultWorkspaceUuidForTenant((string) $account->getTenantId()),
+                    'uuid' => $resolvedAccount->getUuid(),
+                    'email' => $resolvedAccount->getEmail(),
+                    'tenant_id' => $resolvedAccount->getTenantId(),
+                    'roles' => $resolvedAccount->getRoles(),
+                    'default_workspace_uuid' => $this->defaultWorkspaceUuidForTenant((string) $resolvedAccount->getTenantId()),
                 ],
             ], JSON_THROW_ON_ERROR),
             statusCode: 200,
@@ -192,30 +197,7 @@ final class PublicSessionController
 
     private function authenticatedAccountFromSession(): ?AuthenticatedAccount
     {
-        if (session_status() !== \PHP_SESSION_ACTIVE) {
-            session_start();
-        }
-
-        $accountUuid = $_SESSION['claudriel_account_uuid'] ?? null;
-        if (! is_string($accountUuid) || $accountUuid === '') {
-            return null;
-        }
-
-        $ids = $this->entityTypeManager->getStorage('account')->getQuery()
-            ->condition('uuid', $accountUuid)
-            ->range(0, 1)
-            ->execute();
-
-        if ($ids === []) {
-            return null;
-        }
-
-        $account = $this->entityTypeManager->getStorage('account')->load(reset($ids));
-        if (! $account instanceof Account || ! $account->isVerified()) {
-            return null;
-        }
-
-        return new AuthenticatedAccount($account);
+        return (new AuthenticatedAccountSessionResolver($this->entityTypeManager))->resolve();
     }
 
     private function appUrl(string $tenantId, ?string $workspaceUuid): string

--- a/src/Support/AuthenticatedAccountSessionResolver.php
+++ b/src/Support/AuthenticatedAccountSessionResolver.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Support;
+
+use Claudriel\Access\AuthenticatedAccount;
+use Claudriel\Entity\Account;
+use Waaseyaa\Entity\EntityTypeManager;
+
+final class AuthenticatedAccountSessionResolver
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+    ) {}
+
+    public function resolve(): ?AuthenticatedAccount
+    {
+        if (session_status() !== \PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        $accountUuid = $_SESSION['claudriel_account_uuid'] ?? null;
+        if (! is_string($accountUuid) || $accountUuid === '') {
+            return null;
+        }
+
+        $ids = $this->entityTypeManager->getStorage('account')->getQuery()
+            ->condition('uuid', $accountUuid)
+            ->range(0, 1)
+            ->execute();
+
+        if ($ids === []) {
+            return null;
+        }
+
+        $account = $this->entityTypeManager->getStorage('account')->load(reset($ids));
+        if (! $account instanceof Account || ! $account->isVerified()) {
+            return null;
+        }
+
+        return new AuthenticatedAccount($account);
+    }
+}

--- a/tests/Unit/Controller/AppShellControllerTest.php
+++ b/tests/Unit/Controller/AppShellControllerTest.php
@@ -26,9 +26,20 @@ use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\SSR\SsrResponse;
 
 final class AppShellControllerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $this->resetSession();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetSession();
+    }
+
     public function test_show_redirects_anonymous_requests_to_login(): void
     {
         $response = $this->controller()->show();
@@ -57,9 +68,40 @@ final class AppShellControllerTest extends TestCase
 
         $response = $this->controller($entityTypeManager)->show(account: new AuthenticatedAccount($account));
 
+        self::assertInstanceOf(SsrResponse::class, $response);
         self::assertSame(200, $response->statusCode);
         self::assertStringContainsString('App Workspace', $response->content);
         self::assertStringContainsString('guidance-panel', $response->content);
+    }
+
+    public function test_show_renders_dashboard_for_authenticated_session(): void
+    {
+        $entityTypeManager = $this->buildEntityTypeManager();
+        $entityTypeManager->getStorage('workspace')->save(new Workspace([
+            'uuid' => 'workspace-session-shell',
+            'name' => 'Session Workspace',
+            'description' => 'Session-authenticated shell coverage',
+            'tenant_id' => 'tenant-session',
+        ]));
+
+        $account = new Account([
+            'name' => 'Session User',
+            'email' => 'session@example.com',
+            'status' => 'active',
+            'email_verified_at' => '2026-03-14T15:00:00+00:00',
+            'tenant_id' => 'tenant-session',
+        ]);
+        $entityTypeManager->getStorage('account')->save($account);
+        $_SESSION['claudriel_account_uuid'] = $account->get('uuid');
+
+        $response = $this->controller($entityTypeManager)->show(query: [
+            'tenant_id' => 'tenant-session',
+            'workspace_uuid' => 'workspace-session-shell',
+        ]);
+
+        self::assertInstanceOf(SsrResponse::class, $response);
+        self::assertSame(200, $response->statusCode);
+        self::assertStringContainsString('Session Workspace', $response->content);
     }
 
     private function controller(?EntityTypeManager $entityTypeManager = null): AppShellController
@@ -102,5 +144,17 @@ final class AppShellControllerTest extends TestCase
             new EntityType(id: 'triage_entry', label: 'Triage Entry', class: TriageEntry::class, keys: ['id' => 'teid', 'uuid' => 'uuid', 'label' => 'sender_name']),
             new EntityType(id: 'workspace', label: 'Workspace', class: Workspace::class, keys: ['id' => 'wid', 'uuid' => 'uuid', 'label' => 'name']),
         ];
+    }
+
+    private function resetSession(): void
+    {
+        if (session_status() === \PHP_SESSION_ACTIVE) {
+            session_unset();
+            session_destroy();
+        }
+
+        $_SESSION = [];
+        session_id('claudriel-app-shell-'.bin2hex(random_bytes(4)));
+        session_start();
     }
 }

--- a/tests/Unit/Controller/PublicSessionControllerTest.php
+++ b/tests/Unit/Controller/PublicSessionControllerTest.php
@@ -19,6 +19,7 @@ use Waaseyaa\Entity\EntityType;
 use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\EntityStorage\SqlEntityStorage;
 use Waaseyaa\EntityStorage\SqlSchemaHandler;
+use Waaseyaa\SSR\SsrResponse;
 
 final class PublicSessionControllerTest extends TestCase
 {
@@ -36,6 +37,7 @@ final class PublicSessionControllerTest extends TestCase
     {
         $response = $this->controller()->loginForm();
 
+        self::assertInstanceOf(SsrResponse::class, $response);
         self::assertSame(200, $response->statusCode);
         self::assertStringContainsString('Log in to Claudriel', $response->content);
     }
@@ -87,6 +89,24 @@ final class PublicSessionControllerTest extends TestCase
         $logout = $controller->logout();
         self::assertSame('/?logged_out=1', $logout->getTargetUrl());
         self::assertArrayNotHasKey('claudriel_account_uuid', $_SESSION);
+    }
+
+    public function test_session_state_uses_authenticated_session_when_account_argument_is_missing(): void
+    {
+        $entityTypeManager = $this->buildEntityTypeManager();
+        $account = $this->seedVerifiedAccount($entityTypeManager);
+        $entityTypeManager->getStorage('tenant')->save(new Tenant([
+            'uuid' => 'tenant-123',
+            'name' => 'Tenant One',
+            'metadata' => ['default_workspace_uuid' => 'workspace-abc'],
+        ]));
+        $_SESSION['claudriel_account_uuid'] = $account->get('uuid');
+
+        $response = $this->controller($entityTypeManager)->sessionState();
+
+        self::assertSame(200, $response->statusCode);
+        self::assertStringContainsString('test@example.com', $response->content);
+        self::assertStringContainsString('workspace-abc', $response->content);
     }
 
     private function controller(?EntityTypeManager $entityTypeManager = null): PublicSessionController


### PR DESCRIPTION
## Summary
- add a shared authenticated account session resolver for public auth and app-shell entry points
- stop depending on non-running injected account middleware state for `/app`, `/signup`, and `/account/session`
- add regression coverage for session-backed app-shell and session-state behavior

## Checks
- vendor/bin/pint --test
- vendor/bin/phpstan analyse --memory-limit=512M
- composer test -- tests/Unit/Controller/AppShellControllerTest.php tests/Unit/Controller/PublicSessionControllerTest.php tests/Unit/Controller/PublicAccountControllerTest.php
- full pre-push gate: vendor/bin/pint --test, vendor/bin/phpstan analyse, composer test