### PR TITLE
chore(#163): remove dead $twig property writes in controllers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,8 +61,8 @@ parameters:
 			path: src/Command/WorkspacesCommand.php
 
 		-
-			message: '#^Property Claudriel\\Controller\\BriefStreamController\:\:\$twig is never read, only written\.$#'
-			identifier: property.onlyWritten
+			message: '#^Constructor of class Claudriel\\Controller\\BriefStreamController has an unused parameter \$twig\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: src/Controller/BriefStreamController.php
 
@@ -73,8 +73,8 @@ parameters:
 			path: src/Controller/ChatController.php
 
 		-
-			message: '#^Property Claudriel\\Controller\\ChatStreamController\:\:\$twig is never read, only written\.$#'
-			identifier: property.onlyWritten
+			message: '#^Constructor of class Claudriel\\Controller\\ChatStreamController has an unused parameter \$twig\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: src/Controller/ChatStreamController.php
 
@@ -91,8 +91,8 @@ parameters:
 			path: src/Controller/CommitmentUpdateController.php
 
 		-
-			message: '#^Property Claudriel\\Controller\\CommitmentUpdateController\:\:\$twig is never read, only written\.$#'
-			identifier: property.onlyWritten
+			message: '#^Constructor of class Claudriel\\Controller\\CommitmentUpdateController has an unused parameter \$twig\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: src/Controller/CommitmentUpdateController.php
 
@@ -103,8 +103,8 @@ parameters:
 			path: src/Controller/ContextController.php
 
 		-
-			message: '#^Property Claudriel\\Controller\\ContextController\:\:\$twig is never read, only written\.$#'
-			identifier: property.onlyWritten
+			message: '#^Constructor of class Claudriel\\Controller\\ContextController has an unused parameter \$twig\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: src/Controller/ContextController.php
 
@@ -115,8 +115,8 @@ parameters:
 			path: src/Controller/DashboardController.php
 
 		-
-			message: '#^Property Claudriel\\Controller\\IngestController\:\:\$twig is never read, only written\.$#'
-			identifier: property.onlyWritten
+			message: '#^Constructor of class Claudriel\\Controller\\IngestController has an unused parameter \$twig\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: src/Controller/IngestController.php
 
@@ -133,8 +133,8 @@ parameters:
 			path: src/Controller/IngestController.php
 
 		-
-			message: '#^Property Claudriel\\Controller\\WorkspaceApiController\:\:\$twig is never read, only written\.$#'
-			identifier: property.onlyWritten
+			message: '#^Constructor of class Claudriel\\Controller\\WorkspaceApiController has an unused parameter \$twig\.$#'
+			identifier: constructor.unusedParameter
 			count: 1
 			path: src/Controller/WorkspaceApiController.php
 

--- a/src/Controller/BriefStreamController.php
+++ b/src/Controller/BriefStreamController.php
@@ -21,7 +21,7 @@ final class BriefStreamController
 {
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
-        private readonly mixed $twig = null,
+        mixed $twig = null,
     ) {}
 
     /**

--- a/src/Controller/ChatStreamController.php
+++ b/src/Controller/ChatStreamController.php
@@ -27,7 +27,7 @@ final class ChatStreamController
 {
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
-        private readonly mixed $twig = null,
+        mixed $twig = null,
         private readonly mixed $sidecarClientFactory = null,
         private readonly mixed $anthropicClientFactory = null,
         private readonly ?IssueOrchestrator $orchestrator = null,

--- a/src/Controller/CommitmentUpdateController.php
+++ b/src/Controller/CommitmentUpdateController.php
@@ -20,7 +20,7 @@ final class CommitmentUpdateController
 
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
-        private readonly mixed $twig = null,
+        mixed $twig = null,
     ) {}
 
     public function update(array $params, array $query, mixed $account, ?Request $httpRequest = null): SsrResponse

--- a/src/Controller/ContextController.php
+++ b/src/Controller/ContextController.php
@@ -17,7 +17,7 @@ final class ContextController
 {
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
-        private readonly mixed $twig = null,
+        mixed $twig = null,
     ) {}
 
     public function show(array $params = [], array $query = [], mixed $account = null, mixed $httpRequest = null): SsrResponse

--- a/src/Controller/IngestController.php
+++ b/src/Controller/IngestController.php
@@ -28,7 +28,7 @@ final class IngestController
 
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
-        private readonly mixed $twig = null,
+        mixed $twig = null,
     ) {
         $personRepo = new StorageRepositoryAdapter($this->entityTypeManager->getStorage('person'));
         $categorizer = new EventCategorizer(new AutomatedSenderDetector, $personRepo);

--- a/src/Controller/WorkspaceApiController.php
+++ b/src/Controller/WorkspaceApiController.php
@@ -15,7 +15,7 @@ final class WorkspaceApiController
 {
     public function __construct(
         private readonly EntityTypeManager $entityTypeManager,
-        private readonly mixed $twig = null,
+        mixed $twig = null,
     ) {}
 
     public function list(array $params = [], array $query = [], mixed $account = null): SsrResponse


### PR DESCRIPTION
## Summary
- Six controllers accepted `$twig` as a promoted constructor property but never read it
- Demoted to plain parameters so no property is written (dead store eliminated)
- Regenerated PHPStan baseline to match the new error shape
- Affected controllers: IngestController, ContextController, BriefStreamController, ChatStreamController, WorkspaceApiController, CommitmentUpdateController

Closes #163

## Test plan
- [x] `composer lint` passes
- [x] `composer analyse` passes (baseline regenerated)
- [x] `composer test` passes (371 tests, 1239 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)