### PR TITLE
fix(deploy): clear stale manifest cache on deploy

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -97,6 +97,11 @@ task('sidecar:deploy', function (): void {
     run('cd {{deploy_path}}/sidecar && docker compose -f docker-compose.sidecar.yml --env-file .env up -d --build');
 });
 
+desc('Clear stale framework caches from shared storage');
+task('deploy:clear_cache', function (): void {
+    run('rm -f {{deploy_path}}/shared/storage/framework/packages.php');
+});
+
 desc('Validate sidecar health and app smoke probes');
 task('deploy:validate', function (): void {
     $baseUrl = rtrim((string) get('deploy_validation_base_url'), '/');
@@ -150,6 +155,7 @@ task('deploy', [
     'deploy:writable',
     'deploy:copy_caddyfile',
     'deploy:symlink',
+    'deploy:clear_cache',
     'sidecar:deploy',
     'caddy:reload',
     'php-fpm:reload',


### PR DESCRIPTION
## Summary
- The shared `storage/framework/packages.php` cache persists across deploys via Deployer's `shared_dirs`
- When new providers are added (e.g. `I18nServiceProvider` for alpha.8's i18n requirement), the stale cache prevents them from loading
- This caused the `deploy:validate` brief JSON probe to fail: `LanguageManagerInterface not registered`
- Adds a `deploy:clear_cache` task after `deploy:symlink` to remove the cached manifest

## Root cause
The alpha.8 bump added `stripLanguagePrefixForRouting()` to `SsrPageHandler`, which requires `LanguageManagerInterface`. The `I18nServiceProvider` was registered in `composer.json` but the cached manifest on the server predated it.

## Test plan
- [x] `composer lint` passes
- [x] `composer analyse` passes
- [x] `composer test` passes (371 tests)
- [x] Local brief endpoint returns `"counts"` after cache clear
- [ ] Deploy succeeds and `deploy:validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)