### PR TITLE
fix(#188,#189): upgrade to alpha.14 for error traces and provider middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "waaseyaa/database-legacy": "v0.1.0-alpha.13",
         "waaseyaa/entity": "v0.1.0-alpha.13",
         "waaseyaa/entity-storage": "v0.1.0-alpha.13",
-        "waaseyaa/foundation": "v0.1.0-alpha.13",
+        "waaseyaa/foundation": "v0.1.0-alpha.14",
         "waaseyaa/github": "v0.1.0-alpha.13",
         "waaseyaa/graphql": "v0.1.0-alpha.13",
         "waaseyaa/path": "v0.1.0-alpha.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9b241f4fc55b68223f3bfab145353c7",
+    "content-hash": "fb182b7d8adf533c4ad21cf504b75d5a",
     "packages": [
         {
             "name": "doctrine/dbal",
@@ -4684,16 +4684,16 @@
         },
         {
             "name": "waaseyaa/foundation",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/foundation.git",
-                "reference": "79a160a6cdcb031bd53df542415390f227c1699d"
+                "reference": "2399ef364344df326a4e54891c49492b05418182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/79a160a6cdcb031bd53df542415390f227c1699d",
-                "reference": "79a160a6cdcb031bd53df542415390f227c1699d",
+                "url": "https://api.github.com/repos/waaseyaa/foundation/zipball/2399ef364344df326a4e54891c49492b05418182",
+                "reference": "2399ef364344df326a4e54891c49492b05418182",
                 "shasum": ""
             },
             "require": {
@@ -4728,9 +4728,9 @@
             "description": "Core framework primitives: service providers, domain events, results, error handling",
             "support": {
                 "issues": "https://github.com/waaseyaa/foundation/issues",
-                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.14"
             },
-            "time": "2026-03-17T18:52:01+00:00"
+            "time": "2026-03-17T23:00:52+00:00"
         },
         {
             "name": "waaseyaa/github",

--- a/src/Provider/ClaudrielServiceProvider.php
+++ b/src/Provider/ClaudrielServiceProvider.php
@@ -75,6 +75,7 @@ use Claudriel\Entity\TriageEntry;
 use Claudriel\Entity\Workspace;
 use Claudriel\Ingestion\EventCategorizer;
 use Claudriel\Layer2\GitRepositoryManager;
+use Claudriel\Routing\AccountSessionMiddleware;
 use Claudriel\Service\GitOperator;
 use Claudriel\Support\AutomatedSenderDetector;
 use Claudriel\Support\DriftDetector;
@@ -352,6 +353,15 @@ final class ClaudrielServiceProvider extends ServiceProvider
                 $this->resolve(InternalApiTokenGenerator::class),
             );
         });
+    }
+
+    public function middleware(): array
+    {
+        return [
+            new AccountSessionMiddleware(
+                $this->resolve(EntityTypeManager::class),
+            ),
+        ];
     }
 
     public function routes(WaaseyaaRouter $router): void


### PR DESCRIPTION
## Summary

- Upgrade `waaseyaa/foundation` to alpha.14
- Register `AccountSessionMiddleware` via the new `middleware()` method so non-SSR routes receive `AuthenticatedAccount` instead of `AnonymousUser` (#188)
- Alpha.14 includes stack traces in all error_log catch blocks (#189)

Closes #188, #189

## Test plan

- [x] PHPStan clean
- [x] 393 tests passing
- [ ] Deploy to staging, trigger an exception, verify stack trace in error log
- [ ] Verify non-SSR routes receive AuthenticatedAccount

🤖 Generated with [Claude Code](https://claude.com/claude-code)