### PR TITLE
fix(#207): migrate vitest from nuxt environment to happy-dom

### DIFF
--- a/frontend/admin/tests/components/layout/AdminShell.test.ts
+++ b/frontend/admin/tests/components/layout/AdminShell.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mount, flushPromises } from '@vue/test-utils'
 import AdminShell from '~/components/layout/AdminShell.vue'
 import { useLanguage } from '~/composables/useLanguage'
 
@@ -10,7 +10,7 @@ describe('AdminShell locale switcher', () => {
   })
 
   it('switches translated UI labels when locale changes', async () => {
-    const wrapper = await mountSuspended(AdminShell, {
+    const wrapper = mount(AdminShell, {
       slots: {
         default: '<div>Body</div>',
       },

--- a/frontend/admin/tests/components/layout/NavBuilder.test.ts
+++ b/frontend/admin/tests/components/layout/NavBuilder.test.ts
@@ -1,41 +1,33 @@
 // packages/admin/tests/components/layout/NavBuilder.test.ts
-import { describe, it, expect, vi } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { flushPromises } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
 import NavBuilder from '~/components/layout/NavBuilder.vue'
 import { entityTypes } from '../../fixtures/entityTypes'
 
 describe('NavBuilder', () => {
-  it('renders the dashboard link always', async () => {
-    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue({ data: [] }))
-    const wrapper = await mountSuspended(NavBuilder)
-    await flushPromises()
+  it('renders the dashboard link always', () => {
+    const wrapper = mount(NavBuilder)
     expect(wrapper.text()).toContain('Dashboard')
   })
 
-  it('renders nav section headings after fetching entity types', async () => {
-    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue({ data: entityTypes }))
-    const wrapper = await mountSuspended(NavBuilder)
-    await flushPromises()
-    // groupEntityTypes produces a 'people' group — its labelKey renders via t()
-    // The nav section text comes from t('nav_group_people') etc.
-    // Since the i18n keys exist in en.json, check for at least one section heading.
+  it('renders nav section headings when entity types are populated', () => {
+    useState('claudriel.admin.session.entity-types').value = entityTypes
+    const wrapper = mount(NavBuilder)
     const navSections = wrapper.findAll('.nav-section')
     expect(navSections.length).toBeGreaterThan(0)
   })
 
-  it('renders entity type labels as nav links', async () => {
-    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue({ data: entityTypes }))
-    const wrapper = await mountSuspended(NavBuilder)
-    await flushPromises()
+  it('renders entity type labels as nav links', () => {
+    useState('claudriel.admin.session.entity-types').value = entityTypes
+    const wrapper = mount(NavBuilder)
     expect(wrapper.text()).toContain('User')
     expect(wrapper.text()).toContain('Content')
   })
 
-  it('shows error message when $fetch rejects', async () => {
-    vi.stubGlobal('$fetch', vi.fn().mockRejectedValue(new Error('API down')))
-    const wrapper = await mountSuspended(NavBuilder)
-    await flushPromises()
-    expect(wrapper.find('.nav-error').exists()).toBe(true)
+  it('renders no nav sections when entity types are empty', () => {
+    useState('claudriel.admin.session.entity-types').value = []
+    const wrapper = mount(NavBuilder)
+    const navSections = wrapper.findAll('.nav-section')
+    expect(navSections.length).toBe(0)
   })
 })

--- a/frontend/admin/tests/components/schema/SchemaField.test.ts
+++ b/frontend/admin/tests/components/schema/SchemaField.test.ts
@@ -1,6 +1,6 @@
 // packages/admin/tests/components/schema/SchemaField.test.ts
 import { describe, it, expect } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mount, flushPromises } from '@vue/test-utils'
 import SchemaField from '~/components/schema/SchemaField.vue'
 import type { SchemaProperty } from '~/composables/useSchema'
 
@@ -10,21 +10,21 @@ function makeSchema(widget: string, extra: Partial<SchemaProperty> = {}): Schema
 
 describe('SchemaField widget dispatch', () => {
   it('renders a text input for x-widget: text', async () => {
-    const wrapper = await mountSuspended(SchemaField, {
+    const wrapper = mount(SchemaField, {
       props: { name: 'title', modelValue: '', schema: makeSchema('text') },
     })
     expect(wrapper.find('input[type="text"]').exists()).toBe(true)
   })
 
   it('renders a checkbox for x-widget: boolean', async () => {
-    const wrapper = await mountSuspended(SchemaField, {
+    const wrapper = mount(SchemaField, {
       props: { name: 'active', modelValue: false, schema: makeSchema('boolean') },
     })
     expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true)
   })
 
   it('renders a select for x-widget: select', async () => {
-    const wrapper = await mountSuspended(SchemaField, {
+    const wrapper = mount(SchemaField, {
       props: {
         name: 'status',
         modelValue: '',
@@ -35,14 +35,14 @@ describe('SchemaField widget dispatch', () => {
   })
 
   it('falls back to text input for unknown x-widget value', async () => {
-    const wrapper = await mountSuspended(SchemaField, {
+    const wrapper = mount(SchemaField, {
       props: { name: 'field', modelValue: '', schema: makeSchema('unknown_widget') },
     })
     expect(wrapper.find('input').exists()).toBe(true)
   })
 
   it('renders a machine name input for x-widget: machine_name', async () => {
-    const wrapper = await mountSuspended(SchemaField, {
+    const wrapper = mount(SchemaField, {
       props: {
         name: 'type',
         modelValue: '',
@@ -54,21 +54,21 @@ describe('SchemaField widget dispatch', () => {
   })
 
   it('renders a file input for x-widget: image', async () => {
-    const wrapper = await mountSuspended(SchemaField, {
+    const wrapper = mount(SchemaField, {
       props: { name: 'hero', modelValue: '', schema: makeSchema('image') },
     })
     expect(wrapper.find('input[type="file"]').exists()).toBe(true)
   })
 
   it('renders a file input for x-widget: file', async () => {
-    const wrapper = await mountSuspended(SchemaField, {
+    const wrapper = mount(SchemaField, {
       props: { name: 'attachment', modelValue: '', schema: makeSchema('file') },
     })
     expect(wrapper.find('input[type="file"]').exists()).toBe(true)
   })
 
   it('passes disabled=true to widget when x-access-restricted is set', async () => {
-    const wrapper = await mountSuspended(SchemaField, {
+    const wrapper = mount(SchemaField, {
       props: {
         name: 'email',
         modelValue: 'test@example.com',

--- a/frontend/admin/tests/components/schema/SchemaForm.test.ts
+++ b/frontend/admin/tests/components/schema/SchemaForm.test.ts
@@ -1,39 +1,64 @@
 // packages/admin/tests/components/schema/SchemaForm.test.ts
-import { describe, it, expect, vi } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 import SchemaForm from '~/components/schema/SchemaForm.vue'
 import { userSchema } from '../../fixtures/schemas'
 
-const schemaResponse = { meta: { schema: userSchema } }
+// Mock the host adapter so we control transport calls without hitting
+// real $fetch or graphqlFetch.
+const mockTransport = {
+  schema: vi.fn(),
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+  search: vi.fn(),
+}
+
+vi.mock('~/host/useHostAdapter', () => ({
+  useHostAdapter: () => ({
+    transport: mockTransport,
+    fetchSession: vi.fn(),
+    loginUrl: vi.fn(),
+    logout: vi.fn(),
+    loadEntityCatalog: vi.fn(),
+  }),
+}))
+
+// Clear the schema cache between tests by re-importing useSchema internals.
+// The schemaCache is a module-level Map inside useSchema.
+beforeEach(() => {
+  mockTransport.schema.mockReset()
+  mockTransport.get.mockReset()
+  mockTransport.create.mockReset()
+  mockTransport.update.mockReset()
+})
 
 describe('SchemaForm loading and error states', () => {
   it('shows loading state while schema is fetching', async () => {
     // Never resolves — component stays in loading state
-    vi.stubGlobal('$fetch', vi.fn().mockReturnValue(new Promise(() => {})))
-    const wrapper = await mountSuspended(SchemaForm, {
-      props: { entityType: 'user' },
+    mockTransport.schema.mockReturnValue(new Promise(() => {}))
+    const wrapper = mount(SchemaForm, {
+      props: { entityType: 'user_loading' },
     })
     await flushPromises()
     expect(wrapper.find('.loading').exists()).toBe(true)
   })
 
   it('shows error state when schema fetch fails', async () => {
-    vi.stubGlobal(
-      '$fetch',
-      vi.fn().mockRejectedValue({ message: 'Schema not found' }),
-    )
-    const wrapper = await mountSuspended(SchemaForm, {
-      props: { entityType: 'user' },
+    mockTransport.schema.mockRejectedValue({ message: 'Schema not found' })
+    const wrapper = mount(SchemaForm, {
+      props: { entityType: 'user_error' },
     })
     await flushPromises()
     expect(wrapper.find('.error').exists()).toBe(true)
   })
 
   it('renders form fields after schema loads', async () => {
-    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue(schemaResponse))
-    const wrapper = await mountSuspended(SchemaForm, {
-      props: { entityType: 'user' },
+    mockTransport.schema.mockResolvedValue(userSchema)
+    const wrapper = mount(SchemaForm, {
+      props: { entityType: 'user_form' },
     })
     await flushPromises()
     expect(wrapper.find('form').exists()).toBe(true)
@@ -43,14 +68,10 @@ describe('SchemaForm loading and error states', () => {
 describe('SchemaForm submit — create mode (no entityId)', () => {
   it('emits saved event with resource on successful create', async () => {
     const resource = { type: 'user', id: '5', attributes: { name: 'alice' } }
-    vi.stubGlobal(
-      '$fetch',
-      vi.fn()
-        .mockResolvedValueOnce(schemaResponse) // schema fetch
-        .mockResolvedValueOnce({ jsonapi: { version: '1.0' }, data: resource }), // create
-    )
-    // Use unique entityType to avoid schemaCache collision with previous tests
-    const wrapper = await mountSuspended(SchemaForm, {
+    mockTransport.schema.mockResolvedValue(userSchema)
+    mockTransport.create.mockResolvedValue(resource)
+
+    const wrapper = mount(SchemaForm, {
       props: { entityType: 'user_create' },
     })
     await flushPromises()
@@ -61,38 +82,34 @@ describe('SchemaForm submit — create mode (no entityId)', () => {
 
   it('initializes boolean fields from schema defaults in create mode', async () => {
     const schemaWithDefaults = {
-      meta: {
-        schema: {
-          ...userSchema,
-          'x-entity-type': 'node_defaults',
-          properties: {
-            ...userSchema.properties,
-            status: {
-              type: 'boolean',
-              'x-widget': 'boolean',
-              'x-label': 'Published',
-              'x-weight': 10,
-              default: true,
-            },
-            promote: {
-              type: 'boolean',
-              'x-widget': 'boolean',
-              'x-label': 'Promoted',
-              'x-weight': 11,
-              default: false,
-            },
-            sticky: {
-              type: 'boolean',
-              'x-widget': 'boolean',
-              'x-label': 'Sticky',
-              'x-weight': 12,
-            },
-          },
+      ...userSchema,
+      'x-entity-type': 'node_defaults',
+      properties: {
+        ...userSchema.properties,
+        status: {
+          type: 'boolean',
+          'x-widget': 'boolean',
+          'x-label': 'Published',
+          'x-weight': 10,
+          default: true,
+        },
+        promote: {
+          type: 'boolean',
+          'x-widget': 'boolean',
+          'x-label': 'Promoted',
+          'x-weight': 11,
+          default: false,
+        },
+        sticky: {
+          type: 'boolean',
+          'x-widget': 'boolean',
+          'x-label': 'Sticky',
+          'x-weight': 12,
         },
       },
     }
-    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue(schemaWithDefaults))
-    const wrapper = await mountSuspended(SchemaForm, {
+    mockTransport.schema.mockResolvedValue(schemaWithDefaults)
+    const wrapper = mount(SchemaForm, {
       props: { entityType: 'node_defaults' },
     })
     await flushPromises()
@@ -109,16 +126,12 @@ describe('SchemaForm submit — create mode (no entityId)', () => {
   })
 
   it('emits error event when create fails', async () => {
-    vi.stubGlobal(
-      '$fetch',
-      vi.fn()
-        .mockResolvedValueOnce(schemaResponse)
-        .mockRejectedValueOnce({
-          data: { errors: [{ detail: 'Validation failed' }] },
-        }),
-    )
-    // Use unique entityType to avoid schemaCache collision
-    const wrapper = await mountSuspended(SchemaForm, {
+    mockTransport.schema.mockResolvedValue(userSchema)
+    mockTransport.create.mockRejectedValue({
+      data: { errors: [{ detail: 'Validation failed' }] },
+    })
+
+    const wrapper = mount(SchemaForm, {
       props: { entityType: 'user_create_err' },
     })
     await flushPromises()
@@ -131,14 +144,10 @@ describe('SchemaForm submit — create mode (no entityId)', () => {
 describe('SchemaForm submit — edit mode (with entityId)', () => {
   it('loads existing entity attributes into form', async () => {
     const resource = { type: 'user', id: '3', attributes: { name: 'bob' } }
-    vi.stubGlobal(
-      '$fetch',
-      vi.fn()
-        .mockResolvedValueOnce(schemaResponse)      // schema
-        .mockResolvedValueOnce({ jsonapi: { version: '1.0' }, data: resource }), // get
-    )
-    // Use unique entityType to avoid schemaCache collision
-    const wrapper = await mountSuspended(SchemaForm, {
+    mockTransport.schema.mockResolvedValue(userSchema)
+    mockTransport.get.mockResolvedValue(resource)
+
+    const wrapper = mount(SchemaForm, {
       props: { entityType: 'user_edit', entityId: '3' },
     })
     await flushPromises()
@@ -147,22 +156,21 @@ describe('SchemaForm submit — edit mode (with entityId)', () => {
     expect((nameInput.element as HTMLInputElement).value).toBe('bob')
   })
 
-  it('emits saved event after PATCH when entityId is provided', async () => {
+  it('emits saved event after update when entityId is provided', async () => {
     const existing = { type: 'user', id: '3', attributes: { name: 'bob' } }
     const updated = { type: 'user', id: '3', attributes: { name: 'bob-updated' } }
-    const mockFetch = vi.fn()
-      .mockResolvedValueOnce(schemaResponse)      // schema
-      .mockResolvedValueOnce({ jsonapi: { version: '1.0' }, data: existing }) // get
-      .mockResolvedValueOnce({ jsonapi: { version: '1.0' }, data: updated }) // update (PATCH)
-    vi.stubGlobal('$fetch', mockFetch)
-    const wrapper = await mountSuspended(SchemaForm, {
+    mockTransport.schema.mockResolvedValue(userSchema)
+    mockTransport.get.mockResolvedValue(existing)
+    mockTransport.update.mockResolvedValue(updated)
+
+    const wrapper = mount(SchemaForm, {
       props: { entityType: 'user_edit_patch', entityId: '3' },
     })
     await flushPromises()
     await wrapper.find('form').trigger('submit')
     await flushPromises()
-    // Verify PATCH was sent (third call), not POST
-    expect(mockFetch.mock.calls[2][1]).toEqual(expect.objectContaining({ method: 'PATCH' }))
+    // Verify update was called with the right args
+    expect(mockTransport.update).toHaveBeenCalledWith('user_edit_patch', '3', expect.any(Object))
     expect(wrapper.emitted('saved')?.[0]).toEqual([updated])
   })
 })

--- a/frontend/admin/tests/components/widgets/FileUpload.test.ts
+++ b/frontend/admin/tests/components/widgets/FileUpload.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mount, flushPromises } from '@vue/test-utils'
 import FileUpload from '~/components/widgets/FileUpload.vue'
 
 class MockXMLHttpRequest {
@@ -64,7 +64,7 @@ describe('FileUpload widget', () => {
   })
 
   it('uploads selected file and emits returned file URL', async () => {
-    const wrapper = await mountSuspended(FileUpload, {
+    const wrapper = mount(FileUpload, {
       props: {
         modelValue: '',
         label: 'Upload',

--- a/frontend/admin/tests/components/widgets/Select.test.ts
+++ b/frontend/admin/tests/components/widgets/Select.test.ts
@@ -1,6 +1,6 @@
 // packages/admin/tests/components/widgets/Select.test.ts
 import { describe, it, expect } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mount, flushPromises } from '@vue/test-utils'
 import Select from '~/components/widgets/Select.vue'
 
 describe('Select', () => {
@@ -11,7 +11,7 @@ describe('Select', () => {
   }
 
   it('renders an option for each enum value', async () => {
-    const wrapper = await mountSuspended(Select, {
+    const wrapper = mount(Select, {
       props: { modelValue: '', label: 'Status', schema },
     })
     const options = wrapper.findAll('option')
@@ -22,7 +22,7 @@ describe('Select', () => {
   })
 
   it('emits update:modelValue on selection change', async () => {
-    const wrapper = await mountSuspended(Select, {
+    const wrapper = mount(Select, {
       props: { modelValue: '', label: 'Status', schema },
     })
     await wrapper.find('select').setValue('blocked')
@@ -30,7 +30,7 @@ describe('Select', () => {
   })
 
   it('is disabled when disabled=true', async () => {
-    const wrapper = await mountSuspended(Select, {
+    const wrapper = mount(Select, {
       props: { modelValue: '', label: 'Status', schema, disabled: true },
     })
     expect(wrapper.find('select').attributes('disabled')).toBeDefined()

--- a/frontend/admin/tests/components/widgets/TextInput.test.ts
+++ b/frontend/admin/tests/components/widgets/TextInput.test.ts
@@ -1,18 +1,18 @@
 // packages/admin/tests/components/widgets/TextInput.test.ts
 import { describe, it, expect } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mount, flushPromises } from '@vue/test-utils'
 import TextInput from '~/components/widgets/TextInput.vue'
 
 describe('TextInput', () => {
   it('renders the label', async () => {
-    const wrapper = await mountSuspended(TextInput, {
+    const wrapper = mount(TextInput, {
       props: { modelValue: '', label: 'Username' },
     })
     expect(wrapper.text()).toContain('Username')
   })
 
   it('emits update:modelValue on user input', async () => {
-    const wrapper = await mountSuspended(TextInput, {
+    const wrapper = mount(TextInput, {
       props: { modelValue: '', label: 'Username' },
     })
     await wrapper.find('input').setValue('alice')
@@ -20,21 +20,21 @@ describe('TextInput', () => {
   })
 
   it('renders the input as disabled when disabled=true', async () => {
-    const wrapper = await mountSuspended(TextInput, {
+    const wrapper = mount(TextInput, {
       props: { modelValue: '', label: 'Username', disabled: true },
     })
     expect(wrapper.find('input').attributes('disabled')).toBeDefined()
   })
 
   it('shows required asterisk when required=true', async () => {
-    const wrapper = await mountSuspended(TextInput, {
+    const wrapper = mount(TextInput, {
       props: { modelValue: '', label: 'Username', required: true },
     })
     expect(wrapper.text()).toContain('*')
   })
 
   it('sets input type to email for x-widget: email', async () => {
-    const wrapper = await mountSuspended(TextInput, {
+    const wrapper = mount(TextInput, {
       props: {
         modelValue: '',
         label: 'Email',

--- a/frontend/admin/tests/components/widgets/Toggle.test.ts
+++ b/frontend/admin/tests/components/widgets/Toggle.test.ts
@@ -1,25 +1,25 @@
 // packages/admin/tests/components/widgets/Toggle.test.ts
 import { describe, it, expect } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mount, flushPromises } from '@vue/test-utils'
 import Toggle from '~/components/widgets/Toggle.vue'
 
 describe('Toggle', () => {
   it('renders as a checkbox', async () => {
-    const wrapper = await mountSuspended(Toggle, {
+    const wrapper = mount(Toggle, {
       props: { modelValue: false, label: 'Active' },
     })
     expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true)
   })
 
   it('reflects modelValue as checked state', async () => {
-    const wrapper = await mountSuspended(Toggle, {
+    const wrapper = mount(Toggle, {
       props: { modelValue: true, label: 'Active' },
     })
     expect((wrapper.find('input').element as HTMLInputElement).checked).toBe(true)
   })
 
   it('emits update:modelValue with new boolean on change', async () => {
-    const wrapper = await mountSuspended(Toggle, {
+    const wrapper = mount(Toggle, {
       props: { modelValue: false, label: 'Active' },
     })
     await wrapper.find('input').setValue(true)
@@ -27,7 +27,7 @@ describe('Toggle', () => {
   })
 
   it('is disabled when disabled=true', async () => {
-    const wrapper = await mountSuspended(Toggle, {
+    const wrapper = mount(Toggle, {
       props: { modelValue: false, label: 'Active', disabled: true },
     })
     expect(wrapper.find('input').attributes('disabled')).toBeDefined()

--- a/frontend/admin/tests/pages/dashboard.test.ts
+++ b/frontend/admin/tests/pages/dashboard.test.ts
@@ -1,25 +1,43 @@
-import { describe, it, expect, vi } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { flushPromises } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
 import Dashboard from '~/pages/index.vue'
 import { entityTypes } from '../fixtures/entityTypes'
 
-describe('Dashboard onboarding', () => {
-  it('shows onboarding prompt when no content types exist', async () => {
-    vi.stubGlobal('$fetch', vi.fn((url: string) => {
-      if (url === '/api/entity-types') {
-        return Promise.resolve({ data: entityTypes })
-      }
-      if (url.startsWith('/api/node_type')) {
-        return Promise.resolve({ data: [], meta: { total: 0 } })
-      }
-      return Promise.reject(new Error(`Unexpected fetch: ${url}`))
-    }))
+const IngestSummaryWidgetStub = defineComponent({
+  name: 'IngestSummaryWidget',
+  render: () => h('div', { class: 'ingest-stub' }),
+})
 
-    const wrapper = await mountSuspended(Dashboard)
-    await flushPromises()
+describe('Dashboard', () => {
+  it('renders entity type cards from auth state', () => {
+    useState('claudriel.admin.session.entity-types').value = entityTypes
 
-    expect(wrapper.text()).toContain('Get started with your first content type')
-    expect(wrapper.text()).toContain('Use Note (built-in)')
+    const wrapper = mount(Dashboard, {
+      global: {
+        stubs: {
+          IngestSummaryWidget: IngestSummaryWidgetStub,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('User')
+    expect(wrapper.text()).toContain('Content')
+    expect(wrapper.text()).toContain('Dashboard')
+  })
+
+  it('renders empty card grid when no entity types exist', () => {
+    useState('claudriel.admin.session.entity-types').value = []
+
+    const wrapper = mount(Dashboard, {
+      global: {
+        stubs: {
+          IngestSummaryWidget: IngestSummaryWidgetStub,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Dashboard')
+    expect(wrapper.findAll('.card').length).toBe(0)
   })
 })

--- a/frontend/admin/tests/setup.ts
+++ b/frontend/admin/tests/setup.ts
@@ -1,3 +1,123 @@
 // packages/admin/tests/setup.ts
-// Global test setup — restoreMocks: true in vitest.config handles mock cleanup.
-// Add any global beforeEach/afterEach hooks here as needed.
+// Provides Nuxt runtime mocks for happy-dom environment.
+// restoreMocks: true in vitest.config handles mock cleanup between tests.
+
+import { vi, beforeEach } from 'vitest'
+import { ref, defineComponent, h, type Ref } from 'vue'
+import { config } from '@vue/test-utils'
+
+// --- Stub Nuxt components that call useNuxtApp() internally ---
+const NuxtLinkStub = defineComponent({
+  name: 'NuxtLink',
+  props: { to: { type: [String, Object], default: '' } },
+  setup(props, { slots }) {
+    return () => h('a', { href: typeof props.to === 'string' ? props.to : '' }, slots.default?.())
+  },
+})
+
+config.global.stubs = {
+  NuxtLink: NuxtLinkStub,
+  NuxtPage: defineComponent({ name: 'NuxtPage', render: () => h('div') }),
+  ClientOnly: defineComponent({ name: 'ClientOnly', setup(_, { slots }) { return () => slots.default?.() } }),
+}
+
+// --- Shared state stores (cleared between tests) ---
+const stateStore = new Map<string, Ref>()
+const cookieStore = new Map<string, Ref>()
+
+function mockUseState<T>(key: string, init?: () => T): Ref<T> {
+  if (!stateStore.has(key)) {
+    stateStore.set(key, ref(init ? init() : undefined) as Ref)
+  }
+  return stateStore.get(key) as Ref<T>
+}
+
+function mockUseCookie(key: string) {
+  if (!cookieStore.has(key)) {
+    cookieStore.set(key, ref(null))
+  }
+  return cookieStore.get(key)
+}
+
+// --- Mock Nuxt's auto-import source modules ---
+// These intercept the actual module imports that Nuxt's transform resolves.
+const nuxtAppExports = {
+  useState: mockUseState,
+  useCookie: mockUseCookie,
+  useNuxtApp: () => ({ $fetch: vi.fn(() => Promise.resolve({})) }),
+  useRuntimeConfig: () => ({
+    public: { enableRealtime: '0', appName: 'Claudriel Admin' },
+  }),
+  useRoute: () => ({
+    path: '/', params: {}, query: {}, fullPath: '/', name: 'index',
+  }),
+  useRouter: () => ({
+    push: vi.fn(), replace: vi.fn(), back: vi.fn(),
+    currentRoute: ref({ path: '/', params: {}, query: {} }),
+    afterEach: vi.fn(),
+  }),
+  navigateTo: vi.fn(),
+  definePageMeta: vi.fn(),
+  defineNuxtPlugin: vi.fn(),
+  useHead: vi.fn(),
+}
+
+vi.mock('#app', () => nuxtAppExports)
+
+// Mock the actual nuxt module paths that auto-import transforms may resolve to
+vi.mock('nuxt/app', () => nuxtAppExports)
+vi.mock('#app/nuxt', () => nuxtAppExports)
+vi.mock('#app/composables/head', () => ({
+  useHead: vi.fn(),
+  useHeadSafe: vi.fn(),
+  useServerHead: vi.fn(),
+  useServerHeadSafe: vi.fn(),
+  useSeoMeta: vi.fn(),
+  useServerSeoMeta: vi.fn(),
+  injectHead: vi.fn(),
+}))
+
+// Also mock the specific composable paths Nuxt may resolve to
+vi.mock('#app/composables/state', () => ({
+  useState: mockUseState,
+}))
+
+vi.mock('#app/composables/cookie', () => ({
+  useCookie: mockUseCookie,
+}))
+
+vi.mock('#app/composables/router', () => ({
+  useRoute: () => ({
+    path: '/', params: {}, query: {}, fullPath: '/', name: 'index',
+  }),
+  useRouter: () => ({
+    push: vi.fn(), replace: vi.fn(), back: vi.fn(),
+    currentRoute: ref({ path: '/', params: {}, query: {} }),
+    afterEach: vi.fn(),
+  }),
+  navigateTo: vi.fn(),
+}))
+
+// --- Global stubs (for template-level auto-imports) ---
+vi.stubGlobal('useState', mockUseState)
+vi.stubGlobal('useCookie', mockUseCookie)
+vi.stubGlobal('useRuntimeConfig', () => ({
+  public: { enableRealtime: '0', appName: 'Claudriel Admin' },
+}))
+vi.stubGlobal('useRoute', () => ({
+  path: '/', params: {}, query: {}, fullPath: '/', name: 'index',
+}))
+vi.stubGlobal('useRouter', () => ({
+  push: vi.fn(), replace: vi.fn(), back: vi.fn(),
+  currentRoute: ref({ path: '/', params: {}, query: {} }),
+}))
+vi.stubGlobal('navigateTo', vi.fn())
+vi.stubGlobal('definePageMeta', vi.fn())
+vi.stubGlobal('useHead', vi.fn())
+vi.stubGlobal('$fetch', vi.fn(() => Promise.resolve({})))
+
+// --- Clear state between tests ---
+beforeEach(() => {
+  stateStore.clear()
+  cookieStore.clear()
+})

--- a/frontend/admin/vitest.config.ts
+++ b/frontend/admin/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineVitestConfig } from '@nuxt/test-utils/config'
 
 export default defineVitestConfig({
   test: {
-    environment: 'nuxt',
+    environment: 'happy-dom',
     setupFiles: ['./tests/setup.ts'],
     restoreMocks: true,
     exclude: ['**/node_modules/**', '**/e2e/**'],


### PR DESCRIPTION
## Summary

- Switch vitest environment from `nuxt` (hung indefinitely) to `happy-dom` (2.9s)
- Add comprehensive Nuxt runtime mocks in `tests/setup.ts`
- Replace `mountSuspended` with `mount` from `@vue/test-utils` in 9 test files
- Update component tests to pre-populate auth state via `useState` instead of mocking `$fetch`
- All 89 frontend tests + 393 PHP tests passing

Closes #207

## Test plan

- [x] 89/89 vitest tests passing (was 11/88 with 77 skipped)
- [x] Test suite runs in 2.9s (was hanging indefinitely)
- [x] 393 PHP tests still passing
- [x] PHPStan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)