### PR TITLE
chore: upgrade waaseyaa packages to alpha.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,30 +3,24 @@
     "description": "Claudriel — AI personal operations system",
     "type": "project",
     "license": "GPL-2.0-or-later",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/waaseyaa/graphql.git"
-        }
-    ],
     "require": {
         "php": ">=8.4",
-        "waaseyaa/ai-pipeline": "v0.1.0-alpha.13",
-        "waaseyaa/api": "v0.1.0-alpha.13",
-        "waaseyaa/cli": "v0.1.0-alpha.13",
-        "waaseyaa/config": "v0.1.0-alpha.13",
-        "waaseyaa/core": "v0.1.0-alpha.13",
-        "waaseyaa/database-legacy": "v0.1.0-alpha.13",
-        "waaseyaa/entity": "v0.1.0-alpha.13",
-        "waaseyaa/entity-storage": "v0.1.0-alpha.13",
-        "waaseyaa/foundation": "v0.1.0-alpha.16",
-        "waaseyaa/github": "v0.1.0-alpha.13",
-        "waaseyaa/graphql": "v0.1.0-alpha.15",
-        "waaseyaa/path": "v0.1.0-alpha.13",
-        "waaseyaa/routing": "v0.1.0-alpha.13",
-        "waaseyaa/ssr": "v0.1.0-alpha.13",
-        "waaseyaa/admin-surface": "v0.1.0-alpha.13",
-        "waaseyaa/user": "v0.1.0-alpha.13"
+        "waaseyaa/ai-pipeline": "v0.1.0-alpha.17",
+        "waaseyaa/api": "v0.1.0-alpha.17",
+        "waaseyaa/cli": "v0.1.0-alpha.17",
+        "waaseyaa/config": "v0.1.0-alpha.17",
+        "waaseyaa/core": "v0.1.0-alpha.17",
+        "waaseyaa/database-legacy": "v0.1.0-alpha.17",
+        "waaseyaa/entity": "v0.1.0-alpha.17",
+        "waaseyaa/entity-storage": "v0.1.0-alpha.17",
+        "waaseyaa/foundation": "v0.1.0-alpha.17",
+        "waaseyaa/github": "v0.1.0-alpha.17",
+        "waaseyaa/graphql": "v0.1.0-alpha.17",
+        "waaseyaa/path": "v0.1.0-alpha.17",
+        "waaseyaa/routing": "v0.1.0-alpha.17",
+        "waaseyaa/ssr": "v0.1.0-alpha.17",
+        "waaseyaa/admin-surface": "v0.1.0-alpha.17",
+        "waaseyaa/user": "v0.1.0-alpha.17"
     },
     "require-dev": {
         "deployer/deployer": "^7.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3b093e7cca73ff86f197fa13dd5490f",
+    "content-hash": "b6ddf14879812bfb96bc8283c2d40ef4",
     "packages": [
         {
             "name": "doctrine/dbal",
@@ -4054,7 +4054,7 @@
         },
         {
             "name": "waaseyaa/access",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/access.git",
@@ -4096,13 +4096,13 @@
             "description": "Access control and permission system for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/access/issues",
-                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/access/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/admin-surface",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/admin-surface.git",
@@ -4148,13 +4148,13 @@
             "description": "Canonical integration boundary for the Waaseyaa Admin SPA",
             "support": {
                 "issues": "https://github.com/waaseyaa/admin-surface/issues",
-                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/admin-surface/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/ai-pipeline",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-pipeline.git",
@@ -4199,13 +4199,13 @@
             "description": "AI processing pipelines with queue-based execution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-pipeline/issues",
-                "source": "https://github.com/waaseyaa/ai-pipeline/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/ai-pipeline/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/ai-vector",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ai-vector.git",
@@ -4247,13 +4247,13 @@
             "description": "Vector embedding storage and similarity search for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ai-vector/issues",
-                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/ai-vector/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/api",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/api.git",
@@ -4294,13 +4294,13 @@
             "description": "RESTful JSON:API resource layer for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/api/issues",
-                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/api/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/cache",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cache.git",
@@ -4343,13 +4343,13 @@
             "description": "Cache bins with cache tag invalidation for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cache/issues",
-                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/cache/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/cli",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/cli.git",
@@ -4392,13 +4392,13 @@
             "description": "Command-line interface and console commands for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/cli/issues",
-                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/cli/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-17T18:52:01+00:00"
         },
         {
             "name": "waaseyaa/config",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/config.git",
@@ -4437,13 +4437,13 @@
             "description": "Configuration management as YAML with package-aware ownership for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/config/issues",
-                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/config/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/core",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/core.git",
@@ -4489,13 +4489,13 @@
             "description": "Waaseyaa core engine — entities, fields, config, plugins, routing, access.",
             "support": {
                 "issues": "https://github.com/waaseyaa/core/issues",
-                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/core/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/database-legacy",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/database-legacy.git",
@@ -4532,13 +4532,13 @@
             "description": "Database adapter wrapping Drupal DBAL. Interim until Doctrine migration.",
             "support": {
                 "issues": "https://github.com/waaseyaa/database-legacy/issues",
-                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/database-legacy/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/entity",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity.git",
@@ -4584,13 +4584,13 @@
             "description": "Entity type system — types, interfaces, lifecycle, queries. No storage.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity/issues",
-                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/entity/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/entity-storage",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/entity-storage.git",
@@ -4632,13 +4632,13 @@
             "description": "Pluggable entity persistence. v0.1.0: SQL storage behind clean interfaces.",
             "support": {
                 "issues": "https://github.com/waaseyaa/entity-storage/issues",
-                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/entity-storage/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/field",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/field.git",
@@ -4678,13 +4678,13 @@
             "description": "Field type system — pluggable field types, definitions, formatters for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/field/issues",
-                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/field/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/foundation",
-            "version": "v0.1.0-alpha.16",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/foundation.git",
@@ -4728,13 +4728,13 @@
             "description": "Core framework primitives: service providers, domain events, results, error handling",
             "support": {
                 "issues": "https://github.com/waaseyaa/foundation/issues",
-                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.16"
+                "source": "https://github.com/waaseyaa/foundation/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-17T23:44:46+00:00"
         },
         {
             "name": "waaseyaa/github",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/github.git",
@@ -4762,22 +4762,22 @@
             "description": "GitHub API client for issues, milestones, and pull requests",
             "support": {
                 "issues": "https://github.com/waaseyaa/github/issues",
-                "source": "https://github.com/waaseyaa/github/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/github/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T18:56:11+00:00"
         },
         {
             "name": "waaseyaa/graphql",
-            "version": "v0.1.0-alpha.15",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/graphql.git",
-                "reference": "c89883cb824bdfb238f013c08a8319d5b4b62a67"
+                "reference": "ea4fce21f82f19d42886f477819c1fa360febda8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/graphql/zipball/c89883cb824bdfb238f013c08a8319d5b4b62a67",
-                "reference": "c89883cb824bdfb238f013c08a8319d5b4b62a67",
+                "url": "https://api.github.com/repos/waaseyaa/graphql/zipball/ea4fce21f82f19d42886f477819c1fa360febda8",
+                "reference": "ea4fce21f82f19d42886f477819c1fa360febda8",
                 "shasum": ""
             },
             "require": {
@@ -4814,14 +4814,14 @@
             ],
             "description": "GraphQL endpoint for Waaseyaa — auto-generated schema from entity types",
             "support": {
-                "source": "https://github.com/waaseyaa/graphql/tree/v0.1.0-alpha.16",
+                "source": "https://github.com/waaseyaa/graphql/tree/v0.1.0-alpha.17",
                 "issues": "https://github.com/waaseyaa/graphql/issues"
             },
-            "time": "2026-03-17T23:30:10+00:00"
+            "time": "2026-03-18T00:35:20+00:00"
         },
         {
             "name": "waaseyaa/i18n",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/i18n.git",
@@ -4859,13 +4859,13 @@
             "description": "Internationalization foundation: Language, LanguageManager, LanguageContext, FallbackChain",
             "support": {
                 "issues": "https://github.com/waaseyaa/i18n/issues",
-                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/i18n/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/path",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/path.git",
@@ -4908,13 +4908,13 @@
             "description": "URL path aliases and routing integration for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/path/issues",
-                "source": "https://github.com/waaseyaa/path/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/path/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/plugin",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/plugin.git",
@@ -4952,13 +4952,13 @@
             "description": "Attribute-based plugin discovery and management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/plugin/issues",
-                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/plugin/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/queue",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/queue.git",
@@ -4996,13 +4996,13 @@
             "description": "Asynchronous task queue and job processing for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/queue/issues",
-                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/queue/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/routing",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/routing.git",
@@ -5043,13 +5043,13 @@
             "description": "HTTP routing and controller resolution for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/routing/issues",
-                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/routing/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/ssr",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/ssr.git",
@@ -5099,13 +5099,13 @@
             "description": "Server-side rendering with Twig templates for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/ssr/issues",
-                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/ssr/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/state",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/state.git",
@@ -5143,13 +5143,13 @@
             "description": "Key-value state storage for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/state/issues",
-                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/state/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/telescope",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/telescope.git",
@@ -5186,13 +5186,13 @@
             "description": "Application observability and debugging for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/telescope/issues",
-                "source": "https://github.com/waaseyaa/telescope/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/telescope/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/testing",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/testing.git",
@@ -5227,13 +5227,13 @@
             "description": "Testing utilities for Waaseyaa — base test case, entity factories, and helper traits.",
             "support": {
                 "issues": "https://github.com/waaseyaa/testing/issues",
-                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/testing/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/typed-data",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/typed-data.git",
@@ -5271,22 +5271,22 @@
             "description": "Type system with PHP-native facade for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/typed-data/issues",
-                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/typed-data/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/user",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/user.git",
-                "reference": "7db9ac48f9b9dee7942de09be6d7208abb0b1c40"
+                "reference": "1e4e505ea10e67606ada5e2b69a01915f49e68f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/user/zipball/7db9ac48f9b9dee7942de09be6d7208abb0b1c40",
-                "reference": "7db9ac48f9b9dee7942de09be6d7208abb0b1c40",
+                "url": "https://api.github.com/repos/waaseyaa/user/zipball/1e4e505ea10e67606ada5e2b69a01915f49e68f0",
+                "reference": "1e4e505ea10e67606ada5e2b69a01915f49e68f0",
                 "shasum": ""
             },
             "require": {
@@ -5323,13 +5323,13 @@
             "description": "User entity, authentication, and session management for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/user/issues",
-                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/user/tree/v0.1.0-alpha.17"
             },
-            "time": "2026-03-16T21:50:01+00:00"
+            "time": "2026-03-18T00:35:20+00:00"
         },
         {
             "name": "waaseyaa/validation",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/validation.git",
@@ -5368,13 +5368,13 @@
             "description": "Data validation constraints and validators for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/validation/issues",
-                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/validation/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },
         {
             "name": "waaseyaa/workflows",
-            "version": "v0.1.0-alpha.13",
+            "version": "v0.1.0-alpha.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/workflows.git",
@@ -5418,7 +5418,7 @@
             "description": "Content moderation and editorial workflow states for Waaseyaa",
             "support": {
                 "issues": "https://github.com/waaseyaa/workflows/issues",
-                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.13"
+                "source": "https://github.com/waaseyaa/workflows/tree/v0.1.0-alpha.17"
             },
             "time": "2026-03-16T21:50:01+00:00"
         },


### PR DESCRIPTION
## Summary

- Upgrade all waaseyaa packages to v0.1.0-alpha.17
- Remove temporary VCS repository override for graphql package

## Test plan

- [x] PHPStan clean
- [x] 393 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)