### PR TITLE
fix: build admin SPA in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,21 @@ jobs:
             --optimize-autoloader \
             --prefer-dist
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '25'
+          cache: 'npm'
+          cache-dependency-path: claudriel/frontend/admin/package-lock.json
+
+      - name: Build admin SPA
+        working-directory: claudriel/frontend/admin
+        run: |
+          npm ci
+          npm run generate
+          rm -rf ../../public/admin
+          cp -r .output/public ../../public/admin
+
       - name: Assemble build artifact
         run: |
           mkdir -p claudriel/.build

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ waaseyaa.sqlite
 node_modules/
 frontend/admin/.nuxt/
 frontend/admin/.output/
+public/admin/
 
 # User data (gitignored, .gitkeep preserves dirs)
 context/


### PR DESCRIPTION
## Summary

- Add Node 25 setup and nuxt generate step to deploy workflow
- Admin SPA is now built fresh in CI instead of relying on stale committed assets
- Add public/admin/ to .gitignore (generated output)

## Test plan

- [ ] Deploy workflow builds admin SPA successfully
- [ ] Admin UI loads with correct JS modules at /admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)