### PR TITLE
feat(#231): add access policies for 7 entity types

### DIFF
--- a/src/Access/ChatSessionAccessPolicy.php
+++ b/src/Access/ChatSessionAccessPolicy.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Tenant-scoped: owner can CRUD their own sessions.
+ */
+#[PolicyAttribute(entityType: 'chat_session')]
+final class ChatSessionAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'chat_session';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $entityTenantId = $entity->get('tenant_id');
+        $accountTenantId = $account->getTenantId();
+
+        if ($entityTenantId === null || $accountTenantId === null || $entityTenantId !== $accountTenantId) {
+            return AccessResult::forbidden('Tenant mismatch.');
+        }
+
+        $ownerId = $entity->get('owner_id');
+        $accountId = (string) $account->id();
+        $isOwner = $ownerId !== null && (string) $ownerId === $accountId;
+
+        if (! $isOwner) {
+            return AccessResult::forbidden('Users can only access their own chat sessions.');
+        }
+
+        return match ($operation) {
+            'view', 'update', 'delete' => AccessResult::allowed('Owner can manage their chat session.'),
+            default => AccessResult::neutral('Unknown operation.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        if ($account->getTenantId() === null) {
+            return AccessResult::forbidden('No tenant assigned.');
+        }
+
+        return AccessResult::allowed('Authenticated tenant member can create chat sessions.');
+    }
+}

--- a/src/Access/CommitmentAccessPolicy.php
+++ b/src/Access/CommitmentAccessPolicy.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Tenant-scoped: any authenticated user can CRUD within their tenant.
+ */
+#[PolicyAttribute(entityType: 'commitment')]
+final class CommitmentAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'commitment';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $entityTenantId = $entity->get('tenant_id');
+        $accountTenantId = $account->getTenantId();
+
+        if ($entityTenantId === null || $accountTenantId === null || $entityTenantId !== $accountTenantId) {
+            return AccessResult::forbidden('Tenant mismatch.');
+        }
+
+        return match ($operation) {
+            'view', 'update', 'delete' => AccessResult::allowed('Tenant member can manage commitments.'),
+            default => AccessResult::neutral('Unknown operation.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        if ($account->getTenantId() === null) {
+            return AccessResult::forbidden('No tenant assigned.');
+        }
+
+        return AccessResult::allowed('Authenticated tenant member can create commitments.');
+    }
+}

--- a/src/Access/McEventAccessPolicy.php
+++ b/src/Access/McEventAccessPolicy.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Tenant-scoped: read-only for authenticated users (events are created by ingestion).
+ */
+#[PolicyAttribute(entityType: 'mc_event')]
+final class McEventAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'mc_event';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $entityTenantId = $entity->get('tenant_id');
+        $accountTenantId = $account->getTenantId();
+
+        if ($entityTenantId === null || $accountTenantId === null || $entityTenantId !== $accountTenantId) {
+            return AccessResult::forbidden('Tenant mismatch.');
+        }
+
+        return match ($operation) {
+            'view' => AccessResult::allowed('Tenant member can view events.'),
+            default => AccessResult::neutral('Events are read-only; created by ingestion.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return AccessResult::neutral('Events are created by ingestion, not users.');
+    }
+}

--- a/src/Access/PersonAccessPolicy.php
+++ b/src/Access/PersonAccessPolicy.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Tenant-scoped: authenticated users can view/list, admin can edit.
+ */
+#[PolicyAttribute(entityType: 'person')]
+final class PersonAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'person';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $entityTenantId = $entity->get('tenant_id');
+        $accountTenantId = $account->getTenantId();
+
+        if ($entityTenantId === null || $accountTenantId === null || $entityTenantId !== $accountTenantId) {
+            return AccessResult::forbidden('Tenant mismatch.');
+        }
+
+        return match ($operation) {
+            'view' => AccessResult::allowed('Tenant member can view people.'),
+            'update', 'delete' => AccessResult::neutral('Only admins can modify people.'),
+            default => AccessResult::neutral('Unknown operation.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return AccessResult::neutral('Only admins can create people.');
+    }
+}

--- a/src/Access/ScheduleEntryAccessPolicy.php
+++ b/src/Access/ScheduleEntryAccessPolicy.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Tenant-scoped: any authenticated user can CRUD.
+ */
+#[PolicyAttribute(entityType: 'schedule_entry')]
+final class ScheduleEntryAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'schedule_entry';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $entityTenantId = $entity->get('tenant_id');
+        $accountTenantId = $account->getTenantId();
+
+        if ($entityTenantId === null || $accountTenantId === null || $entityTenantId !== $accountTenantId) {
+            return AccessResult::forbidden('Tenant mismatch.');
+        }
+
+        return match ($operation) {
+            'view', 'update', 'delete' => AccessResult::allowed('Tenant member can manage schedule entries.'),
+            default => AccessResult::neutral('Unknown operation.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        if ($account->getTenantId() === null) {
+            return AccessResult::forbidden('No tenant assigned.');
+        }
+
+        return AccessResult::allowed('Authenticated tenant member can create schedule entries.');
+    }
+}

--- a/src/Access/TriageEntryAccessPolicy.php
+++ b/src/Access/TriageEntryAccessPolicy.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Tenant-scoped: read for authenticated, write for system/admin.
+ */
+#[PolicyAttribute(entityType: 'triage_entry')]
+final class TriageEntryAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'triage_entry';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $entityTenantId = $entity->get('tenant_id');
+        $accountTenantId = $account->getTenantId();
+
+        if ($entityTenantId === null || $accountTenantId === null || $entityTenantId !== $accountTenantId) {
+            return AccessResult::forbidden('Tenant mismatch.');
+        }
+
+        return match ($operation) {
+            'view' => AccessResult::allowed('Tenant member can view triage entries.'),
+            default => AccessResult::neutral('Only system or admin can modify triage entries.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        return AccessResult::neutral('Only system or admin can create triage entries.');
+    }
+}

--- a/src/Access/WorkspaceAccessPolicy.php
+++ b/src/Access/WorkspaceAccessPolicy.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Tenant-scoped: owner or admin can CRUD.
+ */
+#[PolicyAttribute(entityType: 'workspace')]
+final class WorkspaceAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'workspace';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $entityTenantId = $entity->get('tenant_id');
+        $accountTenantId = $account->getTenantId();
+
+        if ($entityTenantId === null || $accountTenantId === null || $entityTenantId !== $accountTenantId) {
+            return AccessResult::forbidden('Tenant mismatch.');
+        }
+
+        $ownerId = $entity->get('owner_id');
+        $accountId = (string) $account->id();
+        $isOwner = $ownerId !== null && (string) $ownerId === $accountId;
+
+        return match ($operation) {
+            'view' => AccessResult::allowed('Tenant member can view workspaces.'),
+            'update', 'delete' => $isOwner
+                ? AccessResult::allowed('Owner can modify their workspace.')
+                : AccessResult::neutral('Only owner or admin can modify workspaces.'),
+            default => AccessResult::neutral('Unknown operation.'),
+        };
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        if ($account->getTenantId() === null) {
+            return AccessResult::forbidden('No tenant assigned.');
+        }
+
+        return AccessResult::allowed('Authenticated tenant member can create workspaces.');
+    }
+}


### PR DESCRIPTION
## Summary

- Added 7 tenant-scoped access policies in `src/Access/` following the Waaseyaa `AccessPolicyInterface` + `#[PolicyAttribute]` convention
- Policies: Commitment, Person, McEvent, Workspace, ChatSession, ScheduleEntry, TriageEntry
- Each enforces tenant isolation, admin pass-through, and operation-specific rules

## Test plan
- [x] PHPStan level 5: 0 errors
- [x] Pint: clean
- [ ] Verify policies are discovered by the framework's policy resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)