### PR TITLE
feat(#233): Google OAuth connection management

### DIFF
--- a/src/Controller/GoogleSettingsController.php
+++ b/src/Controller/GoogleSettingsController.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Twig\Environment;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\SSR\SsrResponse;
+
+final class GoogleSettingsController
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly ?Environment $twig = null,
+    ) {}
+
+    public function status(array $params, array $query, AccountInterface $account, Request $httpRequest): SsrResponse
+    {
+        $accountUuid = method_exists($account, 'getUuid') ? $account->getUuid() : '';
+
+        if ($accountUuid === '') {
+            return $this->json(['connected' => false, 'email' => null, 'connected_at' => null]);
+        }
+
+        $integration = $this->findGoogleIntegration($accountUuid);
+
+        if ($integration === null) {
+            return $this->json(['connected' => false, 'email' => null, 'connected_at' => null]);
+        }
+
+        return $this->json([
+            'connected' => true,
+            'email' => $integration->get('google_email') ?? $integration->get('name') ?? null,
+            'connected_at' => $integration->get('created_at'),
+        ]);
+    }
+
+    public function disconnect(array $params, array $query, AccountInterface $account, Request $httpRequest): SsrResponse
+    {
+        $accountUuid = method_exists($account, 'getUuid') ? $account->getUuid() : '';
+
+        if ($accountUuid === '') {
+            return $this->json(['error' => 'Not authenticated'], 401);
+        }
+
+        $integration = $this->findGoogleIntegration($accountUuid);
+
+        if ($integration === null) {
+            return $this->json(['error' => 'No Google connection found'], 404);
+        }
+
+        // Revoke the token at Google
+        $accessToken = $integration->get('access_token');
+        if (is_string($accessToken) && $accessToken !== '') {
+            $this->revokeGoogleToken($accessToken);
+        }
+
+        // Mark integration as disconnected and clear tokens
+        $integration->set('status', 'disconnected');
+        $integration->set('access_token', null);
+        $integration->set('refresh_token', null);
+        $integration->set('token_expires_at', null);
+        $this->entityTypeManager->getStorage('integration')->save($integration);
+
+        return $this->json(['disconnected' => true]);
+    }
+
+    public function show(array $params, array $query, AccountInterface $account, Request $httpRequest): SsrResponse
+    {
+        $accountUuid = method_exists($account, 'getUuid') ? $account->getUuid() : '';
+        $integration = $accountUuid !== '' ? $this->findGoogleIntegration($accountUuid) : null;
+
+        $connected = $integration !== null;
+        $email = $connected ? ($integration->get('google_email') ?? $integration->get('name') ?? '') : '';
+        $connectedAt = $connected ? ($integration->get('created_at') ?? '') : '';
+
+        if ($this->twig !== null) {
+            $html = $this->twig->render('settings.html.twig', [
+                'google_connected' => $connected,
+                'google_email' => $email,
+                'google_connected_at' => $connectedAt,
+            ]);
+
+            return new SsrResponse(
+                content: $html,
+                statusCode: 200,
+                headers: ['Content-Type' => 'text/html; charset=UTF-8'],
+            );
+        }
+
+        return $this->json([
+            'google' => [
+                'connected' => $connected,
+                'email' => $email,
+                'connected_at' => $connectedAt,
+            ],
+        ]);
+    }
+
+    private function findGoogleIntegration(string $accountUuid): ?object
+    {
+        $ids = $this->entityTypeManager->getStorage('integration')->getQuery()
+            ->condition('account_id', $accountUuid)
+            ->condition('provider', 'google')
+            ->condition('status', 'active')
+            ->range(0, 1)
+            ->execute();
+
+        if ($ids === []) {
+            return null;
+        }
+
+        return $this->entityTypeManager->getStorage('integration')->load(reset($ids));
+    }
+
+    private function revokeGoogleToken(string $token): void
+    {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => "Content-Type: application/x-www-form-urlencoded\r\n",
+                'content' => http_build_query(['token' => $token]),
+                'ignore_errors' => true,
+                'timeout' => 5,
+            ],
+        ]);
+
+        file_get_contents('https://oauth2.googleapis.com/revoke', false, $context);
+    }
+
+    private function json(mixed $data, int $statusCode = 200): SsrResponse
+    {
+        return new SsrResponse(
+            content: json_encode($data, JSON_THROW_ON_ERROR),
+            statusCode: $statusCode,
+            headers: ['Content-Type' => 'application/json'],
+        );
+    }
+}

--- a/src/Provider/ClaudrielServiceProvider.php
+++ b/src/Provider/ClaudrielServiceProvider.php
@@ -39,6 +39,7 @@ use Claudriel\Controller\ContextController;
 use Claudriel\Controller\DashboardController;
 use Claudriel\Controller\DayBriefController;
 use Claudriel\Controller\GoogleOAuthController;
+use Claudriel\Controller\GoogleSettingsController;
 use Claudriel\Controller\Governance\CodifiedContextIntegrityController;
 use Claudriel\Controller\IngestController;
 use Claudriel\Controller\InternalGoogleController;
@@ -1193,6 +1194,35 @@ final class ClaudrielServiceProvider extends ServiceProvider
             ->build();
         $googleCallbackRoute->setOption('_csrf', false);
         $router->addRoute('claudriel.auth.google.callback', $googleCallbackRoute);
+
+        // Google settings API
+        $router->addRoute(
+            'claudriel.api.google.status',
+            RouteBuilder::create('/api/google/status')
+                ->controller(GoogleSettingsController::class.'::status')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $googleDisconnectRoute = RouteBuilder::create('/api/google/disconnect')
+            ->controller(GoogleSettingsController::class.'::disconnect')
+            ->allowAll()
+            ->methods('POST')
+            ->build();
+        $googleDisconnectRoute->setOption('_csrf', false);
+        $router->addRoute('claudriel.api.google.disconnect', $googleDisconnectRoute);
+
+        // Settings page
+        $router->addRoute(
+            'claudriel.settings',
+            RouteBuilder::create('/settings')
+                ->controller(GoogleSettingsController::class.'::show')
+                ->allowAll()
+                ->methods('GET')
+                ->render()
+                ->build(),
+        );
 
         // Catch-all: renders 404 for any unmatched path, preventing the
         // foundation render pipeline from failing on PathAliasResolver.

--- a/templates/settings.html.twig
+++ b/templates/settings.html.twig
@@ -1,0 +1,60 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Settings — Claudriel{% endblock %}
+
+{% block content %}
+<div style="max-width: 640px; margin: 40px auto; padding: 0 20px;">
+  <h1 style="font-family: var(--font-display); font-size: 24px; margin-bottom: 32px; color: var(--text-primary);">Settings</h1>
+
+  <section style="background: var(--bg-surface); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin-bottom: 24px;">
+    <h2 style="font-size: 16px; font-weight: 600; margin-bottom: 16px; color: var(--text-primary);">Connected Accounts</h2>
+
+    <div style="display: flex; align-items: center; justify-content: space-between; padding: 16px; background: var(--bg-elevated); border-radius: 8px;">
+      <div style="display: flex; align-items: center; gap: 12px;">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
+        <div>
+          <div style="font-weight: 500; color: var(--text-primary);">Google</div>
+          {% if google_connected %}
+            <div style="font-size: 13px; color: var(--text-secondary);">{{ google_email }}</div>
+          {% else %}
+            <div style="font-size: 13px; color: var(--text-muted);">Not connected</div>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if google_connected %}
+        <button id="disconnect-btn" onclick="confirmDisconnect()" style="padding: 8px 16px; background: transparent; border: 1px solid var(--accent-red); color: var(--accent-red); border-radius: 6px; cursor: pointer; font-size: 13px;">Disconnect</button>
+      {% else %}
+        <a href="/auth/google" style="padding: 8px 16px; background: var(--accent-blue); color: #fff; border-radius: 6px; text-decoration: none; font-size: 13px;">Connect</a>
+      {% endif %}
+    </div>
+  </section>
+
+  <a href="/dashboard" style="color: var(--text-secondary); font-size: 14px; text-decoration: none;">&larr; Back to Dashboard</a>
+</div>
+
+<dialog id="confirm-dialog" style="background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 12px; padding: 24px; color: var(--text-primary); max-width: 400px;">
+  <p style="margin-bottom: 16px;">This will stop email and calendar sync. Continue?</p>
+  <div style="display: flex; gap: 12px; justify-content: flex-end;">
+    <button onclick="document.getElementById('confirm-dialog').close()" style="padding: 8px 16px; background: var(--bg-hover); border: 1px solid var(--border); color: var(--text-secondary); border-radius: 6px; cursor: pointer;">Cancel</button>
+    <button onclick="doDisconnect()" style="padding: 8px 16px; background: var(--accent-red); border: none; color: #fff; border-radius: 6px; cursor: pointer;">Disconnect</button>
+  </div>
+</dialog>
+
+<script>
+function confirmDisconnect() {
+  document.getElementById('confirm-dialog').showModal();
+}
+async function doDisconnect() {
+  document.getElementById('confirm-dialog').close();
+  const btn = document.getElementById('disconnect-btn');
+  btn.textContent = 'Disconnecting...';
+  btn.disabled = true;
+  try {
+    const res = await fetch('/api/google/disconnect', { method: 'POST' });
+    if (res.ok) { window.location.reload(); }
+    else { btn.textContent = 'Error'; }
+  } catch { btn.textContent = 'Error'; }
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- New settings page at `/settings` with Connected Accounts section
- `GET /api/google/status` returns connection state (email, connected_at)
- `POST /api/google/disconnect` revokes token at Google, clears local tokens
- Confirmation dialog before disconnect

## Test plan
- [x] PHPStan level 5: 0 errors
- [x] Pint: clean
- [ ] Verify /settings shows connection status
- [ ] Verify disconnect flow with confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)