### PR TITLE
feat(#246-251): repo connection, git pipeline, agent bridge

### DIFF
--- a/src/Domain/Git/AgentGitBridge.php
+++ b/src/Domain/Git/AgentGitBridge.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Git;
+
+use Claudriel\Entity\Workspace;
+use Waaseyaa\EntityStorage\EntityRepository;
+
+final class AgentGitBridge
+{
+    public function __construct(
+        private readonly EntityRepository $workspaceRepo,
+        private readonly GitPipeline $gitPipeline,
+    ) {}
+
+    /**
+     * Commit all changes in the workspace repo on behalf of the agent.
+     *
+     * @return array{commit_hash: string, pushed: bool}
+     */
+    public function commitForAgent(string $workspaceUuid, string $message): array
+    {
+        $workspace = $this->loadWorkspace($workspaceUuid);
+        $repoPath = $this->resolveRepoPath($workspace);
+
+        $result = $this->gitPipeline->commitAndPush($repoPath, $message);
+
+        $workspace->set('last_commit_hash', $result['commit_hash']);
+        $this->workspaceRepo->save($workspace);
+
+        return $result;
+    }
+
+    /**
+     * Generate a diff for the workspace repo.
+     */
+    public function diffForAgent(string $workspaceUuid): string
+    {
+        $workspace = $this->loadWorkspace($workspaceUuid);
+        $repoPath = $this->resolveRepoPath($workspace);
+
+        return $this->gitPipeline->generateDiff($repoPath);
+    }
+
+    /**
+     * Push the workspace repo to its remote branch.
+     *
+     * @return array{branch: string, pushed: bool}
+     */
+    public function pushForAgent(string $workspaceUuid): array
+    {
+        $workspace = $this->loadWorkspace($workspaceUuid);
+        $repoPath = $this->resolveRepoPath($workspace);
+        $branch = (string) ($workspace->get('branch') ?: 'main');
+
+        $this->gitPipeline->commitAndPush($repoPath, '', $branch);
+
+        return [
+            'branch' => $branch,
+            'pushed' => true,
+        ];
+    }
+
+    private function loadWorkspace(string $workspaceUuid): Workspace
+    {
+        $results = $this->workspaceRepo->findBy(['uuid' => $workspaceUuid]);
+        $workspace = $results[0] ?? null;
+
+        if (! $workspace instanceof Workspace) {
+            throw new \RuntimeException(sprintf('Workspace not found: %s', $workspaceUuid));
+        }
+
+        return $workspace;
+    }
+
+    private function resolveRepoPath(Workspace $workspace): string
+    {
+        $repoPath = (string) $workspace->get('repo_path');
+
+        if ($repoPath === '') {
+            throw new \RuntimeException(sprintf(
+                'Workspace %s has no repo_path configured',
+                (string) $workspace->get('uuid'),
+            ));
+        }
+
+        return $repoPath;
+    }
+}

--- a/src/Domain/Git/GitHubOAuthStub.php
+++ b/src/Domain/Git/GitHubOAuthStub.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Git;
+
+/**
+ * Stub for GitHub OAuth integration.
+ *
+ * TODO: Implement OAuth flow for GitHub App authentication.
+ * TODO: Support token exchange (authorization code → access token).
+ * TODO: Store and refresh tokens per-user.
+ * TODO: Provide authenticated GitHubClient instances.
+ */
+final class GitHubOAuthStub
+{
+    // Future implementation: GitHub OAuth App / GitHub App integration.
+}

--- a/src/Domain/Git/GitOperator.php
+++ b/src/Domain/Git/GitOperator.php
@@ -30,6 +30,18 @@ final class GitOperator
         ));
     }
 
+    public function diffRefs(string $repoPath, string $fromRef, string $toRef): string
+    {
+        $this->assertRepoPath($repoPath);
+
+        return $this->run(sprintf(
+            'git -C %s diff %s %s',
+            escapeshellarg($repoPath),
+            escapeshellarg($fromRef),
+            escapeshellarg($toRef),
+        ));
+    }
+
     public function getStatus(string $repoPath): string
     {
         $this->assertRepoPath($repoPath);

--- a/src/Domain/Git/GitPipeline.php
+++ b/src/Domain/Git/GitPipeline.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Git;
+
+final class GitPipeline
+{
+    public function __construct(
+        private readonly GitOperator $gitOperator,
+    ) {}
+
+    /**
+     * Stage, commit, and push in one operation.
+     *
+     * @return array{commit_hash: string, pushed: bool}
+     */
+    public function commitAndPush(string $repoPath, string $message, ?string $branch = null): array
+    {
+        $commitHash = $this->gitOperator->commit($repoPath, $message);
+
+        $pushed = false;
+        if ($branch !== null) {
+            $this->gitOperator->push($repoPath, $branch);
+            $pushed = true;
+        }
+
+        return [
+            'commit_hash' => $commitHash,
+            'pushed' => $pushed,
+        ];
+    }
+
+    /**
+     * Generate a diff between two refs, or show the working-tree diff.
+     *
+     * When both $fromRef and $toRef are null, delegates to GitOperator::diff()
+     * which shows the diff against HEAD.
+     */
+    public function generateDiff(string $repoPath, ?string $fromRef = null, ?string $toRef = null): string
+    {
+        if ($fromRef === null && $toRef === null) {
+            return $this->gitOperator->diff($repoPath);
+        }
+
+        $from = $fromRef ?? 'HEAD';
+        $to = $toRef ?? 'HEAD';
+
+        return $this->gitOperator->diffRefs($repoPath, $from, $to);
+    }
+}

--- a/src/Domain/Project/ProjectRepoLinker.php
+++ b/src/Domain/Project/ProjectRepoLinker.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Project;
+
+use Claudriel\Entity\Workspace;
+use Waaseyaa\EntityStorage\EntityRepository;
+
+final class ProjectRepoLinker
+{
+    public function __construct(
+        private readonly EntityRepository $workspaceRepo,
+        private readonly EntityRepository $projectRepo,
+    ) {}
+
+    /**
+     * Create a workspace for a repo URL and link it to a project.
+     *
+     * @return string The UUID of the created workspace
+     */
+    public function linkRepo(string $projectUuid, string $repoUrl): string
+    {
+        $this->assertProjectExists($projectUuid);
+
+        $repoName = $this->extractRepoName($repoUrl);
+
+        $workspace = new Workspace([
+            'name' => $repoName,
+            'description' => sprintf('Repository workspace for %s', $repoUrl),
+            'repo_url' => $repoUrl,
+            'project_id' => $projectUuid,
+        ]);
+
+        $this->workspaceRepo->save($workspace);
+
+        return (string) $workspace->get('uuid');
+    }
+
+    /**
+     * Unlink a workspace from a project by setting project_id to null.
+     */
+    public function unlinkRepo(string $projectUuid, string $workspaceUuid): void
+    {
+        $this->assertProjectExists($projectUuid);
+
+        $results = $this->workspaceRepo->findBy(['uuid' => $workspaceUuid]);
+        $workspace = $results[0] ?? null;
+
+        if (! $workspace instanceof Workspace) {
+            throw new \RuntimeException(sprintf('Workspace not found: %s', $workspaceUuid));
+        }
+
+        if ($workspace->get('project_id') !== $projectUuid) {
+            throw new \RuntimeException(sprintf(
+                'Workspace %s is not linked to project %s',
+                $workspaceUuid,
+                $projectUuid,
+            ));
+        }
+
+        $workspace->set('project_id', null);
+        $this->workspaceRepo->save($workspace);
+    }
+
+    /**
+     * List all workspaces linked to a project that have a repo_url set.
+     *
+     * @return Workspace[]
+     */
+    public function listRepos(string $projectUuid): array
+    {
+        $this->assertProjectExists($projectUuid);
+
+        $results = $this->workspaceRepo->findBy(['project_id' => $projectUuid]);
+
+        return array_values(array_filter(
+            $results,
+            static fn (mixed $ws): bool => $ws instanceof Workspace
+                && $ws->get('repo_url') !== null
+                && $ws->get('repo_url') !== '',
+        ));
+    }
+
+    private function assertProjectExists(string $projectUuid): void
+    {
+        $results = $this->projectRepo->findBy(['uuid' => $projectUuid]);
+
+        if (($results[0] ?? null) === null) {
+            throw new \RuntimeException(sprintf('Project not found: %s', $projectUuid));
+        }
+    }
+
+    private function extractRepoName(string $repoUrl): string
+    {
+        $path = parse_url($repoUrl, PHP_URL_PATH);
+
+        if ($path === null || $path === false) {
+            // SSH format: git@host:owner/repo.git
+            $parts = explode(':', $repoUrl);
+            $path = $parts[1] ?? $repoUrl;
+        }
+
+        $basename = basename((string) $path);
+
+        return str_ends_with($basename, '.git')
+            ? substr($basename, 0, -4)
+            : $basename;
+    }
+}

--- a/src/Domain/Workspace/RepoConnectionService.php
+++ b/src/Domain/Workspace/RepoConnectionService.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Workspace;
+
+use Claudriel\Domain\Git\GitRepositoryManager;
+use Claudriel\Entity\Workspace;
+use Waaseyaa\EntityStorage\EntityRepository;
+
+final class RepoConnectionService
+{
+    public function __construct(
+        private readonly EntityRepository $workspaceRepo,
+        private readonly GitRepositoryManager $gitRepositoryManager,
+    ) {}
+
+    /**
+     * Connect a repository to a workspace by URL.
+     *
+     * Validates the URL format (https or ssh), sets workspace fields,
+     * and triggers a clone via GitRepositoryManager.
+     */
+    public function connect(string $workspaceUuid, string $repoUrl, ?string $branch = 'main'): void
+    {
+        $branch = $branch ?? 'main';
+
+        $this->validateRepoUrl($repoUrl);
+
+        $workspace = $this->loadWorkspace($workspaceUuid);
+
+        $repoPath = $this->gitRepositoryManager->buildWorkspaceRepoPath($workspaceUuid);
+
+        $workspace->set('repo_url', $repoUrl);
+        $workspace->set('branch', $branch);
+        $workspace->set('repo_path', $repoPath);
+
+        $this->workspaceRepo->save($workspace);
+
+        $this->gitRepositoryManager->clone($repoUrl, $repoPath, $branch);
+    }
+
+    private function validateRepoUrl(string $repoUrl): void
+    {
+        $httpsPattern = '#^https://[a-zA-Z0-9._\-]+(/[a-zA-Z0-9._\-]+)+(?:\.git)?$#';
+        $sshPattern = '#^git@[a-zA-Z0-9._\-]+:[a-zA-Z0-9._\-]+(/[a-zA-Z0-9._\-]+)+(?:\.git)?$#';
+
+        if (preg_match($httpsPattern, $repoUrl) !== 1 && preg_match($sshPattern, $repoUrl) !== 1) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid repository URL: %s. Must be https:// or git@ (SSH) format.',
+                $repoUrl,
+            ));
+        }
+    }
+
+    private function loadWorkspace(string $workspaceUuid): Workspace
+    {
+        $results = $this->workspaceRepo->findBy(['uuid' => $workspaceUuid]);
+        $workspace = $results[0] ?? null;
+
+        if (! $workspace instanceof Workspace) {
+            throw new \RuntimeException(sprintf('Workspace not found: %s', $workspaceUuid));
+        }
+
+        return $workspace;
+    }
+}


### PR DESCRIPTION
## Summary

Batch 3 of v1.8:
- **#246**: RepoConnectionService — URL validation, workspace field wiring, clone trigger
- **#247**: ProjectRepoLinker — multi-repo linking for projects
- **#248/#249**: GitPipeline — unified commitAndPush + generateDiff
- **#250**: AgentGitBridge — workspace-aware git ops for agent subprocess
- **#251**: GitHubOAuthStub — future milestone placeholder

## Test plan
- [x] PHPStan clean
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)