### PR TITLE
feat(#240-245): workspace modes, lifecycle manager, git worktree

### DIFF
--- a/src/Domain/Git/GitWorktreeManager.php
+++ b/src/Domain/Git/GitWorktreeManager.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Git;
+
+final class GitWorktreeManager
+{
+    /** @var callable(string): array{exit_code:int,output:string} */
+    private readonly mixed $runner;
+
+    public function __construct(
+        ?callable $runner = null,
+    ) {
+        $this->runner = $runner ?? $this->defaultRunner(...);
+    }
+
+    /**
+     * Create a git worktree for the given branch.
+     *
+     * @return string The path to the created worktree
+     */
+    public function createWorktree(string $repoPath, string $branch): string
+    {
+        $this->assertGitRepository($repoPath);
+
+        $worktreePath = rtrim($repoPath, '/').'/../worktrees/'.$this->sanitizeBranchName($branch);
+        $worktreePath = realpath(dirname($worktreePath)) !== false
+            ? realpath(dirname($worktreePath)).'/'.basename($worktreePath)
+            : $worktreePath;
+
+        $parent = dirname($worktreePath);
+        if (! is_dir($parent) && ! mkdir($parent, 0755, true) && ! is_dir($parent)) {
+            throw new \RuntimeException(sprintf('Failed to create worktree parent directory: %s', $parent));
+        }
+
+        $this->run(sprintf(
+            'git -C %s worktree add %s %s',
+            escapeshellarg($repoPath),
+            escapeshellarg($worktreePath),
+            escapeshellarg($branch),
+        ));
+
+        return $worktreePath;
+    }
+
+    /**
+     * Remove a git worktree.
+     */
+    public function removeWorktree(string $worktreePath): void
+    {
+        if (! is_dir($worktreePath)) {
+            throw new \RuntimeException(sprintf('Worktree path not found: %s', $worktreePath));
+        }
+
+        $this->run(sprintf(
+            'git -C %s worktree remove %s --force',
+            escapeshellarg($worktreePath),
+            escapeshellarg($worktreePath),
+        ));
+    }
+
+    /**
+     * List all worktrees for a repository.
+     *
+     * @return list<array{path:string,head:string,branch:string}>
+     */
+    public function listWorktrees(string $repoPath): array
+    {
+        $this->assertGitRepository($repoPath);
+
+        $output = $this->run(sprintf(
+            'git -C %s worktree list --porcelain',
+            escapeshellarg($repoPath),
+        ));
+
+        $worktrees = [];
+        $current = [];
+
+        foreach (explode("\n", $output) as $line) {
+            $line = trim($line);
+            if ($line === '') {
+                if ($current !== []) {
+                    $worktrees[] = [
+                        'path' => $current['worktree'] ?? '',
+                        'head' => $current['HEAD'] ?? '',
+                        'branch' => isset($current['branch']) ? str_replace('refs/heads/', '', $current['branch']) : '',
+                    ];
+                    $current = [];
+                }
+
+                continue;
+            }
+
+            $parts = explode(' ', $line, 2);
+            if (count($parts) === 2) {
+                $current[$parts[0]] = $parts[1];
+            }
+        }
+
+        if ($current !== []) {
+            $worktrees[] = [
+                'path' => $current['worktree'] ?? '',
+                'head' => $current['HEAD'] ?? '',
+                'branch' => isset($current['branch']) ? str_replace('refs/heads/', '', $current['branch']) : '',
+            ];
+        }
+
+        return $worktrees;
+    }
+
+    private function sanitizeBranchName(string $branch): string
+    {
+        return str_replace(['/', '\\', '..'], ['-', '-', ''], $branch);
+    }
+
+    private function assertGitRepository(string $path): void
+    {
+        if (! is_dir($path.'/.git')) {
+            throw new \RuntimeException(sprintf('Git repository not found at %s', $path));
+        }
+    }
+
+    private function run(string $command): string
+    {
+        $result = ($this->runner)($command);
+        $exitCode = (int) ($result['exit_code'] ?? 1);
+        $output = (string) ($result['output'] ?? '');
+
+        if ($exitCode !== 0) {
+            throw new \RuntimeException(trim($output) !== '' ? trim($output) : sprintf('Command failed: %s', $command));
+        }
+
+        return $output;
+    }
+
+    /**
+     * @return array{exit_code:int,output:string}
+     */
+    private function defaultRunner(string $command): array
+    {
+        $marker = '__CLAUDRIEL_GIT_EXIT_CODE__';
+        $output = shell_exec($command.' 2>&1; printf "\n'.$marker.'%s" "$?"');
+
+        if ($output === null) {
+            return ['exit_code' => 1, 'output' => 'shell_exec returned null'];
+        }
+
+        $pos = strrpos($output, $marker);
+        if ($pos === false) {
+            return ['exit_code' => 1, 'output' => trim($output)];
+        }
+
+        $commandOutput = substr($output, 0, $pos);
+        $exitCode = (int) trim(substr($output, $pos + strlen($marker)));
+
+        return [
+            'exit_code' => $exitCode,
+            'output' => trim($commandOutput),
+        ];
+    }
+}

--- a/src/Domain/Workspace/WorkspaceLifecycleManager.php
+++ b/src/Domain/Workspace/WorkspaceLifecycleManager.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Workspace;
+
+use Claudriel\Domain\Git\GitRepositoryManager;
+use Claudriel\Entity\Workspace;
+use Waaseyaa\Entity\EntityTypeManager;
+
+final class WorkspaceLifecycleManager
+{
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+        private readonly GitRepositoryManager $gitRepositoryManager,
+    ) {}
+
+    /**
+     * Create a workspace with optional git repository cloning.
+     *
+     * @param  array<string,mixed>  $data
+     */
+    public function create(array $data): Workspace
+    {
+        $mode = $data['mode'] ?? 'persistent';
+        if (! in_array($mode, ['persistent', 'ephemeral'], true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid workspace mode: %s', $mode));
+        }
+
+        $data['mode'] = $mode;
+        $data['status'] = $data['status'] ?? 'active';
+
+        $workspace = new Workspace($data);
+        $storage = $this->entityTypeManager->getStorage('workspace');
+        $storage->save($workspace);
+
+        $repoUrl = trim((string) ($data['repo_url'] ?? ''));
+        if ($repoUrl !== '') {
+            $uuid = (string) $workspace->get('uuid');
+            $localPath = $this->gitRepositoryManager->buildWorkspaceRepoPath($uuid);
+            $branch = trim((string) ($data['branch'] ?? 'main'));
+
+            $this->gitRepositoryManager->clone($repoUrl, $localPath, $branch);
+
+            $workspace->set('repo_path', $localPath);
+            $workspace->set('last_commit_hash', $this->gitRepositoryManager->getLatestCommit($localPath));
+            $storage->save($workspace);
+        }
+
+        return $workspace;
+    }
+
+    /**
+     * Archive a workspace (sets status to archived).
+     */
+    public function archive(string $uuid): void
+    {
+        $workspace = $this->loadByUuid($uuid);
+        $workspace->set('status', 'archived');
+        $this->entityTypeManager->getStorage('workspace')->save($workspace);
+    }
+
+    /**
+     * Restore an archived workspace (sets status to active).
+     */
+    public function restore(string $uuid): void
+    {
+        $workspace = $this->loadByUuid($uuid);
+
+        if ($workspace->get('status') !== 'archived') {
+            throw new \RuntimeException(sprintf('Workspace %s is not archived (current status: %s)', $uuid, (string) $workspace->get('status')));
+        }
+
+        $workspace->set('status', 'active');
+        $this->entityTypeManager->getStorage('workspace')->save($workspace);
+    }
+
+    /**
+     * Destroy an ephemeral workspace. Refuses to destroy persistent workspaces.
+     * Cleans up local git repository if present.
+     */
+    public function destroy(string $uuid): void
+    {
+        $workspace = $this->loadByUuid($uuid);
+
+        if ($workspace->get('mode') !== 'ephemeral') {
+            throw new \RuntimeException(sprintf('Cannot destroy persistent workspace %s. Archive it instead.', $uuid));
+        }
+
+        $repoPath = trim((string) ($workspace->get('repo_path') ?? ''));
+        if ($repoPath !== '' && is_dir($repoPath)) {
+            $this->removeDirectory($repoPath);
+        }
+
+        $this->entityTypeManager->getStorage('workspace')->delete([$workspace]);
+    }
+
+    /**
+     * Compute current status from git state.
+     *
+     * @return 'active'|'archived'|'drifted'|'syncing'
+     */
+    public function computeStatus(string $uuid): string
+    {
+        $workspace = $this->loadByUuid($uuid);
+        $currentStatus = (string) $workspace->get('status');
+
+        if ($currentStatus === 'archived') {
+            return 'archived';
+        }
+
+        if ($currentStatus === 'syncing') {
+            return 'syncing';
+        }
+
+        if ($this->isDrifted($workspace)) {
+            return 'drifted';
+        }
+
+        return 'active';
+    }
+
+    /**
+     * Check if local workspace is behind remote.
+     */
+    public function isDrifted(Workspace $workspace): bool
+    {
+        $repoPath = trim((string) ($workspace->get('repo_path') ?? ''));
+        if ($repoPath === '' || ! is_dir($repoPath.'/.git')) {
+            return false;
+        }
+
+        try {
+            $localHash = $this->gitRepositoryManager->getLatestCommit($repoPath);
+            $storedHash = trim((string) ($workspace->get('last_commit_hash') ?? ''));
+
+            if ($storedHash === '' || $localHash === $storedHash) {
+                return false;
+            }
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * Check if a git operation is in progress (lock file exists).
+     */
+    public function isSyncing(Workspace $workspace): bool
+    {
+        $repoPath = trim((string) ($workspace->get('repo_path') ?? ''));
+        if ($repoPath === '') {
+            return false;
+        }
+
+        return file_exists($repoPath.'/.git/index.lock');
+    }
+
+    private function loadByUuid(string $uuid): Workspace
+    {
+        $storage = $this->entityTypeManager->getStorage('workspace');
+        $all = $storage->loadMultiple();
+
+        foreach ($all as $entity) {
+            if ($entity instanceof Workspace && $entity->get('uuid') === $uuid) {
+                return $entity;
+            }
+        }
+
+        throw new \RuntimeException(sprintf('Workspace not found: %s', $uuid));
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $file) {
+            /** @var \SplFileInfo $file */
+            if ($file->isDir()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/src/Entity/Workspace.php
+++ b/src/Entity/Workspace.php
@@ -53,5 +53,11 @@ final class Workspace extends ContentEntityBase
         if ($this->get('project_id') === null) {
             $this->set('project_id', null);
         }
+        if ($this->get('mode') === null) {
+            $this->set('mode', 'persistent');
+        }
+        if ($this->get('status') === null) {
+            $this->set('status', 'active');
+        }
     }
 }

--- a/src/Provider/WorkspaceServiceProvider.php
+++ b/src/Provider/WorkspaceServiceProvider.php
@@ -34,6 +34,8 @@ final class WorkspaceServiceProvider extends ServiceProvider
                 'last_commit_hash' => ['type' => 'string'],
                 'ci_status' => ['type' => 'string'],
                 'project_id' => ['type' => 'string'],
+                'mode' => ['type' => 'string'],
+                'status' => ['type' => 'string'],
                 'created_at' => ['type' => 'timestamp', 'readOnly' => true],
                 'updated_at' => ['type' => 'timestamp', 'readOnly' => true],
             ],


### PR DESCRIPTION
## Summary

Batch 2 of v1.8:
- **#240**: Workspace persistent/ephemeral mode field
- **#241**: WorkspaceLifecycleManager (create, archive, destroy, restore)
- **#242**: Git integration in lifecycle (clone on create, cleanup on destroy)
- **#243**: GitWorktreeManager (create/remove/list worktrees)
- **#244**: Workspace entity field alignment (mode, status)
- **#245**: Status indicators (active, archived, drifted, syncing)

## Test plan
- [x] PHPStan level 5 clean
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)