### PR TITLE
fix(#423): template Caddyfile for staging/production environments

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,16 +1,15 @@
-# claudriel.ai - included via import in main /etc/caddy/Caddyfile
-# Deploy path: ~/claudriel-prod, current release: ~/claudriel-prod/current
+# __CADDY_DOMAIN__ - included via import in main /etc/caddy/Caddyfile
+# Deploy path: __DEPLOY_PATH__, current release: __DEPLOY_PATH__/current
 
-claudriel.ai {
+__CADDY_DOMAIN__ {
   tls {
-    issuer acme {
-    }
+    issuer acme
   }
 
   # Keep browsers on HTTP/2 or HTTP/1.1 for SSE; QUIC has been flaky for EventSource.
   header Alt-Svc "clear"
 
-  root * /home/deployer/claudriel-prod/current/public
+  root * __DEPLOY_PATH__/current/public
 
   @not_stream {
     not path /stream/*
@@ -69,7 +68,7 @@ claudriel.ai {
   }
 
   log {
-    output file /home/deployer/claudriel-prod/log/access.log {
+    output file __DEPLOY_PATH__/log/access.log {
       mode 0644
     }
   }

--- a/deploy.php
+++ b/deploy.php
@@ -72,9 +72,13 @@ task('deploy:upload', function (): void {
     ]);
 });
 
-desc('Copy Caddyfile to deploy root');
+desc('Copy Caddyfile to deploy root with environment substitution');
 task('deploy:copy_caddyfile', function (): void {
-    run('cp {{release_path}}/Caddyfile {{deploy_path}}/Caddyfile');
+    $baseUrl = get('deploy_validation_base_url');
+    $domain = (string) parse_url($baseUrl, PHP_URL_HOST);
+    $deployPath = get('deploy_path');
+
+    run("sed -e 's|__CADDY_DOMAIN__|{$domain}|g' -e 's|__DEPLOY_PATH__|{$deployPath}|g' {{release_path}}/Caddyfile > {{deploy_path}}/Caddyfile");
 });
 
 desc('Ensure shared runtime directories exist');


### PR DESCRIPTION
## Summary
- Template Caddyfile with `__CADDY_DOMAIN__` and `__DEPLOY_PATH__` placeholders, substituted per environment during deploy
- Fix invalid `issuer acme {}` empty block that caused Caddy reload failures
- Staging now correctly gets `claudriel.northcloud.one` instead of colliding with production's `claudriel.ai`

Closes #423

## Test plan
- [ ] Deploy to staging succeeds with `claudriel.northcloud.one` in generated Caddyfile
- [ ] Deploy to production succeeds with `claudriel.ai` in generated Caddyfile
- [ ] `caddy validate` passes after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)