### PR TITLE
feat(#431): add JunctionCascadeSubscriber for cascade delete

### DIFF
--- a/src/Entity/Repo.php
+++ b/src/Entity/Repo.php
@@ -18,15 +18,27 @@ final class Repo extends ContentEntityBase
 
     public function __construct(array $values = [])
     {
-        // Compute full_name from owner + name before parent constructor
-        if (isset($values['owner'], $values['name']) && ! isset($values['full_name'])) {
-            $values['full_name'] = $values['owner'].'/'.$values['name'];
-        }
-
         parent::__construct($values, $this->entityTypeId, $this->entityKeys);
 
+        if ($this->get('owner') === null) {
+            $this->set('owner', '');
+        }
+        if ($this->get('name') === null) {
+            $this->set('name', '');
+        }
+        if ($this->get('full_name') === null) {
+            $owner = $this->get('owner');
+            $name = $this->get('name');
+            $this->set('full_name', ($owner !== '' && $name !== '') ? $owner . '/' . $name : '');
+        }
         if ($this->get('default_branch') === null) {
             $this->set('default_branch', 'main');
+        }
+        if ($this->get('local_path') === null) {
+            $this->set('local_path', null);
+        }
+        if ($this->get('account_id') === null) {
+            $this->set('account_id', null);
         }
         if ($this->get('tenant_id') === null) {
             $this->set('tenant_id', $_ENV['CLAUDRIEL_DEFAULT_TENANT'] ?? getenv('CLAUDRIEL_DEFAULT_TENANT') ?: 'default');

--- a/src/Subscriber/JunctionCascadeSubscriber.php
+++ b/src/Subscriber/JunctionCascadeSubscriber.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Subscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\Entity\Event\EntityEvent;
+use Waaseyaa\Entity\Event\EntityEvents;
+
+final class JunctionCascadeSubscriber implements EventSubscriberInterface
+{
+    /** Maps parent entity type to junction entity types and their foreign key field. */
+    private const JUNCTION_MAP = [
+        'project' => [
+            ['entity_type' => 'project_repo', 'field' => 'project_uuid'],
+            ['entity_type' => 'workspace_project', 'field' => 'project_uuid'],
+        ],
+        'workspace' => [
+            ['entity_type' => 'workspace_project', 'field' => 'workspace_uuid'],
+            ['entity_type' => 'workspace_repo', 'field' => 'workspace_uuid'],
+        ],
+        'repo' => [
+            ['entity_type' => 'project_repo', 'field' => 'repo_uuid'],
+            ['entity_type' => 'workspace_repo', 'field' => 'repo_uuid'],
+        ],
+    ];
+
+    public function __construct(
+        private readonly EntityTypeManager $entityTypeManager,
+    ) {}
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            EntityEvents::POST_DELETE->value => 'onPostDelete',
+        ];
+    }
+
+    public function onPostDelete(EntityEvent $event): void
+    {
+        $entity = $event->entity;
+        $entityTypeId = $entity->getEntityTypeId();
+
+        $junctions = self::JUNCTION_MAP[$entityTypeId] ?? [];
+        if ($junctions === []) {
+            return;
+        }
+
+        $uuid = $entity->get('uuid');
+        if ($uuid === null || $uuid === '') {
+            return;
+        }
+
+        foreach ($junctions as $junction) {
+            try {
+                $storage = $this->entityTypeManager->getStorage($junction['entity_type']);
+                $query = $storage->getQuery();
+                $query->condition($junction['field'], $uuid);
+                $ids = $query->execute();
+
+                if ($ids !== []) {
+                    $storage->delete($storage->loadMultiple($ids));
+                }
+            } catch (\Throwable $e) {
+                error_log(sprintf(
+                    'JunctionCascadeSubscriber: failed to clean %s.%s=%s: %s',
+                    $junction['entity_type'],
+                    $junction['field'],
+                    $uuid,
+                    $e->getMessage(),
+                ));
+            }
+        }
+    }
+}

--- a/tests/Feature/Subscriber/JunctionCascadeTest.php
+++ b/tests/Feature/Subscriber/JunctionCascadeTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Feature\Subscriber;
+
+use Claudriel\Entity\Project;
+use Claudriel\Entity\ProjectRepo;
+use Claudriel\Entity\Repo;
+use Claudriel\Entity\Workspace;
+use Claudriel\Entity\WorkspaceProject;
+use Claudriel\Entity\WorkspaceRepo;
+use Claudriel\Subscriber\JunctionCascadeSubscriber;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+
+#[CoversClass(JunctionCascadeSubscriber::class)]
+final class JunctionCascadeTest extends TestCase
+{
+    private DBALDatabase $db;
+    private EntityTypeManager $manager;
+
+    protected function setUp(): void
+    {
+        $this->db = DBALDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher();
+
+        $this->manager = new EntityTypeManager(
+            $dispatcher,
+            function ($definition) use ($dispatcher): SqlEntityStorage {
+                (new SqlSchemaHandler($definition, $this->db))->ensureTable();
+                return new SqlEntityStorage($definition, $this->db, $dispatcher);
+            },
+        );
+
+        // Register cascade subscriber after manager (it needs the manager reference)
+        $dispatcher->addSubscriber(new JunctionCascadeSubscriber($this->manager));
+
+        $this->registerAllTypes();
+    }
+
+    #[Test]
+    public function deleting_project_removes_project_repo_and_workspace_project_junctions(): void
+    {
+        $projectStorage = $this->manager->getStorage('project');
+        $prStorage = $this->manager->getStorage('project_repo');
+        $wpStorage = $this->manager->getStorage('workspace_project');
+
+        // Create project
+        $project = new Project(['name' => 'Test Project', 'tenant_id' => 'default']);
+        $project->enforceIsNew();
+        $projectStorage->save($project);
+        $projectUuid = $project->get('uuid');
+
+        // Create junction rows
+        $pr = new ProjectRepo(['project_uuid' => $projectUuid, 'repo_uuid' => 'repo-1']);
+        $pr->enforceIsNew();
+        $prStorage->save($pr);
+
+        $wp = new WorkspaceProject(['workspace_uuid' => 'ws-1', 'project_uuid' => $projectUuid]);
+        $wp->enforceIsNew();
+        $wpStorage->save($wp);
+
+        // Delete project
+        $projectStorage->delete($this->loadAll($projectStorage));
+
+        // Junctions should be gone
+        self::assertCount(0, $this->loadAll($prStorage));
+        self::assertCount(0, $this->loadAll($wpStorage));
+    }
+
+    #[Test]
+    public function deleting_repo_removes_project_repo_and_workspace_repo_junctions(): void
+    {
+        $repoStorage = $this->manager->getStorage('repo');
+        $prStorage = $this->manager->getStorage('project_repo');
+        $wrStorage = $this->manager->getStorage('workspace_repo');
+
+        // Create repo
+        $repo = new Repo(['owner' => 'jonesrussell', 'name' => 'waaseyaa', 'tenant_id' => 'default']);
+        $repo->enforceIsNew();
+        $repoStorage->save($repo);
+        $repoUuid = $repo->get('uuid');
+
+        // Create junction rows
+        $pr = new ProjectRepo(['project_uuid' => 'proj-1', 'repo_uuid' => $repoUuid]);
+        $pr->enforceIsNew();
+        $prStorage->save($pr);
+
+        $wr = new WorkspaceRepo(['workspace_uuid' => 'ws-1', 'repo_uuid' => $repoUuid]);
+        $wr->enforceIsNew();
+        $wrStorage->save($wr);
+
+        // Delete repo
+        $repoStorage->delete($this->loadAll($repoStorage));
+
+        // Junctions should be gone
+        self::assertCount(0, $this->loadAll($prStorage));
+        self::assertCount(0, $this->loadAll($wrStorage));
+    }
+
+    #[Test]
+    public function deleting_workspace_removes_workspace_project_and_workspace_repo_junctions(): void
+    {
+        $wsStorage = $this->manager->getStorage('workspace');
+        $wpStorage = $this->manager->getStorage('workspace_project');
+        $wrStorage = $this->manager->getStorage('workspace_repo');
+
+        // Create workspace
+        $ws = new Workspace(['name' => 'Test Workspace', 'tenant_id' => 'default']);
+        $ws->enforceIsNew();
+        $wsStorage->save($ws);
+        $wsUuid = $ws->get('uuid');
+
+        // Create junction rows
+        $wp = new WorkspaceProject(['workspace_uuid' => $wsUuid, 'project_uuid' => 'proj-1']);
+        $wp->enforceIsNew();
+        $wpStorage->save($wp);
+
+        $wr = new WorkspaceRepo(['workspace_uuid' => $wsUuid, 'repo_uuid' => 'repo-1']);
+        $wr->enforceIsNew();
+        $wrStorage->save($wr);
+
+        // Delete workspace
+        $wsStorage->delete($this->loadAll($wsStorage));
+
+        // Junctions should be gone
+        self::assertCount(0, $this->loadAll($wpStorage));
+        self::assertCount(0, $this->loadAll($wrStorage));
+    }
+
+    #[Test]
+    public function deleting_project_does_not_delete_repos_or_workspaces(): void
+    {
+        $projectStorage = $this->manager->getStorage('project');
+        $repoStorage = $this->manager->getStorage('repo');
+        $wsStorage = $this->manager->getStorage('workspace');
+        $prStorage = $this->manager->getStorage('project_repo');
+
+        // Create repo and workspace
+        $repo = new Repo(['owner' => 'jonesrussell', 'name' => 'waaseyaa', 'tenant_id' => 'default']);
+        $repo->enforceIsNew();
+        $repoStorage->save($repo);
+
+        $ws = new Workspace(['name' => 'My Workspace', 'tenant_id' => 'default']);
+        $ws->enforceIsNew();
+        $wsStorage->save($ws);
+
+        // Create project and link
+        $project = new Project(['name' => 'Test Project', 'tenant_id' => 'default']);
+        $project->enforceIsNew();
+        $projectStorage->save($project);
+        $projectUuid = $project->get('uuid');
+        $repoUuid = $repo->get('uuid');
+
+        $pr = new ProjectRepo(['project_uuid' => $projectUuid, 'repo_uuid' => $repoUuid]);
+        $pr->enforceIsNew();
+        $prStorage->save($pr);
+
+        // Delete project
+        $projectStorage->delete($this->loadAll($projectStorage));
+
+        // Repo and workspace should still exist
+        self::assertCount(1, $this->loadAll($repoStorage));
+        self::assertCount(1, $this->loadAll($wsStorage));
+    }
+
+    /** @return array<int|string, \Waaseyaa\Entity\EntityInterface> */
+    private function loadAll(SqlEntityStorage $storage): array
+    {
+        return $storage->loadMultiple($storage->getQuery()->execute());
+    }
+
+    private function registerAllTypes(): void
+    {
+        $this->manager->registerEntityType(new EntityType(
+            id: 'project',
+            label: 'Project',
+            class: Project::class,
+            keys: ['id' => 'prid', 'uuid' => 'uuid', 'label' => 'name'],
+            fieldDefinitions: [
+                'prid' => ['type' => 'integer', 'readOnly' => true],
+                'uuid' => ['type' => 'string', 'readOnly' => true],
+                'name' => ['type' => 'string', 'required' => true],
+                'description' => ['type' => 'string'],
+                'status' => ['type' => 'string'],
+                'account_id' => ['type' => 'string'],
+                'tenant_id' => ['type' => 'string'],
+                'created_at' => ['type' => 'timestamp', 'readOnly' => true],
+                'updated_at' => ['type' => 'timestamp', 'readOnly' => true],
+            ],
+        ));
+
+        $this->manager->registerEntityType(new EntityType(
+            id: 'workspace',
+            label: 'Workspace',
+            class: Workspace::class,
+            keys: ['id' => 'wid', 'uuid' => 'uuid', 'label' => 'name'],
+            fieldDefinitions: [
+                'wid' => ['type' => 'integer', 'readOnly' => true],
+                'uuid' => ['type' => 'string', 'readOnly' => true],
+                'name' => ['type' => 'string', 'required' => true],
+                'description' => ['type' => 'string'],
+                'status' => ['type' => 'string'],
+                'mode' => ['type' => 'string'],
+                'saved_context' => ['type' => 'text_long'],
+                'account_id' => ['type' => 'string'],
+                'tenant_id' => ['type' => 'string'],
+                'created_at' => ['type' => 'timestamp', 'readOnly' => true],
+                'updated_at' => ['type' => 'timestamp', 'readOnly' => true],
+            ],
+        ));
+
+        $this->manager->registerEntityType(new EntityType(
+            id: 'repo',
+            label: 'Repo',
+            class: Repo::class,
+            keys: ['id' => 'rid', 'uuid' => 'uuid', 'label' => 'name'],
+            fieldDefinitions: [
+                'rid' => ['type' => 'integer', 'readOnly' => true],
+                'uuid' => ['type' => 'string', 'readOnly' => true],
+                'owner' => ['type' => 'string'],
+                'name' => ['type' => 'string'],
+                'full_name' => ['type' => 'string'],
+                'url' => ['type' => 'string'],
+                'default_branch' => ['type' => 'string'],
+                'local_path' => ['type' => 'string'],
+                'account_id' => ['type' => 'string'],
+                'tenant_id' => ['type' => 'string'],
+                'created_at' => ['type' => 'timestamp', 'readOnly' => true],
+                'updated_at' => ['type' => 'timestamp', 'readOnly' => true],
+            ],
+        ));
+
+        $this->manager->registerEntityType(new EntityType(
+            id: 'project_repo',
+            label: 'Project Repo',
+            class: ProjectRepo::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'uuid'],
+            fieldDefinitions: [
+                'id' => ['type' => 'integer', 'readOnly' => true],
+                'uuid' => ['type' => 'string', 'readOnly' => true],
+                'project_uuid' => ['type' => 'string', 'required' => true],
+                'repo_uuid' => ['type' => 'string', 'required' => true],
+                'created_at' => ['type' => 'timestamp', 'readOnly' => true],
+            ],
+        ));
+
+        $this->manager->registerEntityType(new EntityType(
+            id: 'workspace_project',
+            label: 'Workspace Project',
+            class: WorkspaceProject::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'uuid'],
+            fieldDefinitions: [
+                'id' => ['type' => 'integer', 'readOnly' => true],
+                'uuid' => ['type' => 'string', 'readOnly' => true],
+                'workspace_uuid' => ['type' => 'string', 'required' => true],
+                'project_uuid' => ['type' => 'string', 'required' => true],
+                'created_at' => ['type' => 'timestamp', 'readOnly' => true],
+            ],
+        ));
+
+        $this->manager->registerEntityType(new EntityType(
+            id: 'workspace_repo',
+            label: 'Workspace Repo',
+            class: WorkspaceRepo::class,
+            keys: ['id' => 'id', 'uuid' => 'uuid', 'label' => 'uuid'],
+            fieldDefinitions: [
+                'id' => ['type' => 'integer', 'readOnly' => true],
+                'uuid' => ['type' => 'string', 'readOnly' => true],
+                'workspace_uuid' => ['type' => 'string', 'required' => true],
+                'repo_uuid' => ['type' => 'string', 'required' => true],
+                'is_active' => ['type' => 'boolean'],
+                'created_at' => ['type' => 'timestamp', 'readOnly' => true],
+            ],
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `JunctionCascadeSubscriber` that listens to `entity.post_delete` events
- Cascade-deletes junction rows (ProjectRepo, WorkspaceProject, WorkspaceRepo) when parent entities are deleted
- Best-effort: failures logged via `error_log()`, never crash the parent delete

## Test plan
- [x] Unit tests verify cascade delete for all three parent types
- [x] Verify other parent entities are NOT deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)