### PR TITLE
feat(#434): add access policies for Project, Workspace, Repo

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,9 @@
         <testsuite name="Integration">
             <directory>tests/Integration</directory>
         </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/src/Access/ProjectAccessPolicy.php
+++ b/src/Access/ProjectAccessPolicy.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Tenant-scoped: owner can CRUD, tenant members can view.
+ */
+#[PolicyAttribute(entityType: 'project')]
+final class ProjectAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'project';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $accountId = (string) $account->id();
+
+        if ($entity->get('account_id') === $accountId) {
+            return AccessResult::allowed('Owner can manage their project.');
+        }
+
+        $entityTenantId = $entity->get('tenant_id');
+        $accountTenantId = $account->getTenantId();
+
+        if ($entityTenantId !== null && $accountTenantId !== null && $entityTenantId === $accountTenantId) {
+            return match ($operation) {
+                'view' => AccessResult::allowed('Tenant member can view projects.'),
+                'update', 'delete' => AccessResult::neutral('Only owner or admin can modify projects.'),
+                default => AccessResult::neutral('Unknown operation.'),
+            };
+        }
+
+        return AccessResult::neutral('No access granted.');
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        if ($account->getTenantId() === null) {
+            return AccessResult::forbidden('No tenant assigned.');
+        }
+
+        return AccessResult::allowed('Authenticated tenant member can create projects.');
+    }
+}

--- a/src/Access/RepoAccessPolicy.php
+++ b/src/Access/RepoAccessPolicy.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Access;
+
+use Waaseyaa\Access\AccessPolicyInterface;
+use Waaseyaa\Access\AccessResult;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Access\Gate\PolicyAttribute;
+use Waaseyaa\Entity\EntityInterface;
+
+/**
+ * Tenant-scoped: owner can CRUD, tenant members can view.
+ */
+#[PolicyAttribute(entityType: 'repo')]
+final class RepoAccessPolicy implements AccessPolicyInterface
+{
+    public function appliesTo(string $entityTypeId): bool
+    {
+        return $entityTypeId === 'repo';
+    }
+
+    public function access(EntityInterface $entity, string $operation, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        $accountId = (string) $account->id();
+
+        if ($entity->get('account_id') === $accountId) {
+            return AccessResult::allowed('Owner can manage their repo.');
+        }
+
+        $entityTenantId = $entity->get('tenant_id');
+        $accountTenantId = $account->getTenantId();
+
+        if ($entityTenantId !== null && $accountTenantId !== null && $entityTenantId === $accountTenantId) {
+            return match ($operation) {
+                'view' => AccessResult::allowed('Tenant member can view repos.'),
+                'update', 'delete' => AccessResult::neutral('Only owner or admin can modify repos.'),
+                default => AccessResult::neutral('Unknown operation.'),
+            };
+        }
+
+        return AccessResult::neutral('No access granted.');
+    }
+
+    public function createAccess(string $entityTypeId, string $bundle, AccountInterface $account): AccessResult
+    {
+        if (! $account->isAuthenticated()) {
+            return AccessResult::unauthenticated('Authentication required.');
+        }
+
+        if ($account->hasPermission('administer content')) {
+            return AccessResult::allowed('Admin permission.');
+        }
+
+        if ($account->getTenantId() === null) {
+            return AccessResult::forbidden('No tenant assigned.');
+        }
+
+        return AccessResult::allowed('Authenticated tenant member can create repos.');
+    }
+}

--- a/src/Access/WorkspaceAccessPolicy.php
+++ b/src/Access/WorkspaceAccessPolicy.php
@@ -11,7 +11,7 @@ use Waaseyaa\Access\Gate\PolicyAttribute;
 use Waaseyaa\Entity\EntityInterface;
 
 /**
- * Tenant-scoped: owner or admin can CRUD.
+ * Personal: only owner can CRUD. Workspaces are not shared within a tenant.
  */
 #[PolicyAttribute(entityType: 'workspace')]
 final class WorkspaceAccessPolicy implements AccessPolicyInterface
@@ -31,22 +31,14 @@ final class WorkspaceAccessPolicy implements AccessPolicyInterface
             return AccessResult::allowed('Admin permission.');
         }
 
-        $entityTenantId = $entity->get('tenant_id');
-        $accountTenantId = $account->getTenantId();
+        $accountId = (string) $account->id();
 
-        if ($entityTenantId === null || $accountTenantId === null || $entityTenantId !== $accountTenantId) {
-            return AccessResult::forbidden('Tenant mismatch.');
+        if ($entity->get('account_id') !== $accountId) {
+            return AccessResult::forbidden('Workspaces are personal. Only the owner can access.');
         }
 
-        $ownerId = $entity->get('owner_id');
-        $accountId = (string) $account->id();
-        $isOwner = $ownerId !== null && (string) $ownerId === $accountId;
-
         return match ($operation) {
-            'view' => AccessResult::allowed('Tenant member can view workspaces.'),
-            'update', 'delete' => $isOwner
-                ? AccessResult::allowed('Owner can modify their workspace.')
-                : AccessResult::neutral('Only owner or admin can modify workspaces.'),
+            'view', 'update', 'delete' => AccessResult::allowed('Owner can manage their workspace.'),
             default => AccessResult::neutral('Unknown operation.'),
         };
     }
@@ -57,14 +49,6 @@ final class WorkspaceAccessPolicy implements AccessPolicyInterface
             return AccessResult::unauthenticated('Authentication required.');
         }
 
-        if ($account->hasPermission('administer content')) {
-            return AccessResult::allowed('Admin permission.');
-        }
-
-        if ($account->getTenantId() === null) {
-            return AccessResult::forbidden('No tenant assigned.');
-        }
-
-        return AccessResult::allowed('Authenticated tenant member can create workspaces.');
+        return AccessResult::allowed('Authenticated user can create workspaces.');
     }
 }

--- a/tests/Feature/Access/AccessPolicyTestHelpers.php
+++ b/tests/Feature/Access/AccessPolicyTestHelpers.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Feature\Access;
+
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\EntityInterface;
+
+trait AccessPolicyTestHelpers
+{
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function createEntity(string $entityTypeId, array $fields): EntityInterface
+    {
+        return new class ($entityTypeId, $fields) implements EntityInterface {
+            /**
+             * @param array<string, mixed> $fields
+             */
+            public function __construct(
+                private readonly string $entityTypeId,
+                private readonly array $fields,
+            ) {}
+
+            public function get(string $field): mixed
+            {
+                return $this->fields[$field] ?? null;
+            }
+
+            public function id(): int|string|null
+            {
+                return $this->fields['id'] ?? 1;
+            }
+
+            public function uuid(): string
+            {
+                return '';
+            }
+
+            public function label(): string
+            {
+                return 'Test ' . $this->entityTypeId;
+            }
+
+            public function getEntityTypeId(): string
+            {
+                return $this->entityTypeId;
+            }
+
+            public function bundle(): string
+            {
+                return $this->entityTypeId;
+            }
+
+            public function toArray(): array
+            {
+                return $this->fields;
+            }
+
+            public function isNew(): bool
+            {
+                return false;
+            }
+
+            public function language(): string
+            {
+                return 'en';
+            }
+        };
+    }
+
+    private function createAuthenticatedAccount(int $id, ?string $tenantId, bool $isAdmin = false): AccountInterface
+    {
+        return new class ($id, $tenantId, $isAdmin) implements AccountInterface {
+            public function __construct(
+                private readonly int $accountId,
+                private readonly ?string $tenantId,
+                private readonly bool $isAdmin,
+            ) {}
+
+            public function id(): int|string
+            {
+                return $this->accountId;
+            }
+
+            public function isAuthenticated(): bool
+            {
+                return true;
+            }
+
+            public function hasPermission(string $permission): bool
+            {
+                return $this->isAdmin && $permission === 'administer content';
+            }
+
+            public function getRoles(): array
+            {
+                return [];
+            }
+
+            public function getTenantId(): ?string
+            {
+                return $this->tenantId;
+            }
+        };
+    }
+
+    private function createAnonymousAccount(): AccountInterface
+    {
+        return new class implements AccountInterface {
+            public function id(): int|string
+            {
+                return 0;
+            }
+
+            public function isAuthenticated(): bool
+            {
+                return false;
+            }
+
+            public function hasPermission(string $permission): bool
+            {
+                return false;
+            }
+
+            public function getRoles(): array
+            {
+                return [];
+            }
+
+            public function getTenantId(): ?string
+            {
+                return null;
+            }
+        };
+    }
+}

--- a/tests/Feature/Access/ProjectAccessPolicyTest.php
+++ b/tests/Feature/Access/ProjectAccessPolicyTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Feature\Access;
+
+use Claudriel\Access\ProjectAccessPolicy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ProjectAccessPolicy::class)]
+final class ProjectAccessPolicyTest extends TestCase
+{
+    use AccessPolicyTestHelpers;
+
+    private ProjectAccessPolicy $policy;
+
+    protected function setUp(): void
+    {
+        $this->policy = new ProjectAccessPolicy();
+    }
+
+    #[Test]
+    public function applies_to_project_entity_type(): void
+    {
+        self::assertTrue($this->policy->appliesTo('project'));
+        self::assertFalse($this->policy->appliesTo('repo'));
+    }
+
+    #[Test]
+    public function unauthenticated_user_is_denied(): void
+    {
+        $entity = $this->createEntity('project', ['account_id' => '1', 'tenant_id' => 'tenant-1']);
+        $account = $this->createAnonymousAccount();
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        self::assertTrue($result->isUnauthenticated());
+    }
+
+    #[Test]
+    public function owner_can_view_update_delete(): void
+    {
+        $entity = $this->createEntity('project', ['account_id' => '42', 'tenant_id' => 'tenant-1']);
+        $account = $this->createAuthenticatedAccount(42, 'tenant-1');
+
+        foreach (['view', 'update', 'delete'] as $operation) {
+            $result = $this->policy->access($entity, $operation, $account);
+            self::assertTrue($result->isAllowed(), "Owner should be allowed to {$operation}.");
+        }
+    }
+
+    #[Test]
+    public function tenant_member_can_view_but_not_update_or_delete(): void
+    {
+        $entity = $this->createEntity('project', ['account_id' => '42', 'tenant_id' => 'tenant-1']);
+        $account = $this->createAuthenticatedAccount(99, 'tenant-1');
+
+        $viewResult = $this->policy->access($entity, 'view', $account);
+        self::assertTrue($viewResult->isAllowed(), 'Tenant member should view.');
+
+        $updateResult = $this->policy->access($entity, 'update', $account);
+        self::assertTrue($updateResult->isNeutral(), 'Tenant member should not update.');
+
+        $deleteResult = $this->policy->access($entity, 'delete', $account);
+        self::assertTrue($deleteResult->isNeutral(), 'Tenant member should not delete.');
+    }
+
+    #[Test]
+    public function non_tenant_user_gets_neutral(): void
+    {
+        $entity = $this->createEntity('project', ['account_id' => '42', 'tenant_id' => 'tenant-1']);
+        $account = $this->createAuthenticatedAccount(99, 'tenant-2');
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        self::assertTrue($result->isNeutral());
+    }
+
+    #[Test]
+    public function create_access_allowed_for_authenticated_with_tenant(): void
+    {
+        $account = $this->createAuthenticatedAccount(1, 'tenant-1');
+
+        $result = $this->policy->createAccess('project', 'project', $account);
+
+        self::assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function create_access_forbidden_without_tenant(): void
+    {
+        $account = $this->createAuthenticatedAccount(1, null);
+
+        $result = $this->policy->createAccess('project', 'project', $account);
+
+        self::assertTrue($result->isForbidden());
+    }
+
+    #[Test]
+    public function create_access_denied_for_anonymous(): void
+    {
+        $account = $this->createAnonymousAccount();
+
+        $result = $this->policy->createAccess('project', 'project', $account);
+
+        self::assertTrue($result->isUnauthenticated());
+    }
+}

--- a/tests/Feature/Access/RepoAccessPolicyTest.php
+++ b/tests/Feature/Access/RepoAccessPolicyTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Feature\Access;
+
+use Claudriel\Access\RepoAccessPolicy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RepoAccessPolicy::class)]
+final class RepoAccessPolicyTest extends TestCase
+{
+    use AccessPolicyTestHelpers;
+
+    private RepoAccessPolicy $policy;
+
+    protected function setUp(): void
+    {
+        $this->policy = new RepoAccessPolicy();
+    }
+
+    #[Test]
+    public function applies_to_repo_entity_type(): void
+    {
+        self::assertTrue($this->policy->appliesTo('repo'));
+        self::assertFalse($this->policy->appliesTo('project'));
+    }
+
+    #[Test]
+    public function unauthenticated_user_is_denied(): void
+    {
+        $entity = $this->createEntity('repo', ['account_id' => '1', 'tenant_id' => 'tenant-1']);
+        $account = $this->createAnonymousAccount();
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        self::assertTrue($result->isUnauthenticated());
+    }
+
+    #[Test]
+    public function owner_can_view_update_delete(): void
+    {
+        $entity = $this->createEntity('repo', ['account_id' => '42', 'tenant_id' => 'tenant-1']);
+        $account = $this->createAuthenticatedAccount(42, 'tenant-1');
+
+        foreach (['view', 'update', 'delete'] as $operation) {
+            $result = $this->policy->access($entity, $operation, $account);
+            self::assertTrue($result->isAllowed(), "Owner should be allowed to {$operation}.");
+        }
+    }
+
+    #[Test]
+    public function tenant_member_can_view_but_not_update_or_delete(): void
+    {
+        $entity = $this->createEntity('repo', ['account_id' => '42', 'tenant_id' => 'tenant-1']);
+        $account = $this->createAuthenticatedAccount(99, 'tenant-1');
+
+        $viewResult = $this->policy->access($entity, 'view', $account);
+        self::assertTrue($viewResult->isAllowed(), 'Tenant member should view.');
+
+        $updateResult = $this->policy->access($entity, 'update', $account);
+        self::assertTrue($updateResult->isNeutral(), 'Tenant member should not update.');
+
+        $deleteResult = $this->policy->access($entity, 'delete', $account);
+        self::assertTrue($deleteResult->isNeutral(), 'Tenant member should not delete.');
+    }
+
+    #[Test]
+    public function non_tenant_user_gets_neutral(): void
+    {
+        $entity = $this->createEntity('repo', ['account_id' => '42', 'tenant_id' => 'tenant-1']);
+        $account = $this->createAuthenticatedAccount(99, 'tenant-2');
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        self::assertTrue($result->isNeutral());
+    }
+
+    #[Test]
+    public function create_access_allowed_for_authenticated_with_tenant(): void
+    {
+        $account = $this->createAuthenticatedAccount(1, 'tenant-1');
+
+        $result = $this->policy->createAccess('repo', 'repo', $account);
+
+        self::assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function create_access_forbidden_without_tenant(): void
+    {
+        $account = $this->createAuthenticatedAccount(1, null);
+
+        $result = $this->policy->createAccess('repo', 'repo', $account);
+
+        self::assertTrue($result->isForbidden());
+    }
+
+    #[Test]
+    public function create_access_denied_for_anonymous(): void
+    {
+        $account = $this->createAnonymousAccount();
+
+        $result = $this->policy->createAccess('repo', 'repo', $account);
+
+        self::assertTrue($result->isUnauthenticated());
+    }
+}

--- a/tests/Feature/Access/WorkspaceAccessPolicyTest.php
+++ b/tests/Feature/Access/WorkspaceAccessPolicyTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Feature\Access;
+
+use Claudriel\Access\WorkspaceAccessPolicy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(WorkspaceAccessPolicy::class)]
+final class WorkspaceAccessPolicyTest extends TestCase
+{
+    use AccessPolicyTestHelpers;
+
+    private WorkspaceAccessPolicy $policy;
+
+    protected function setUp(): void
+    {
+        $this->policy = new WorkspaceAccessPolicy();
+    }
+
+    #[Test]
+    public function applies_to_workspace_entity_type(): void
+    {
+        self::assertTrue($this->policy->appliesTo('workspace'));
+        self::assertFalse($this->policy->appliesTo('project'));
+    }
+
+    #[Test]
+    public function unauthenticated_user_is_denied(): void
+    {
+        $entity = $this->createEntity('workspace', ['account_id' => '1']);
+        $account = $this->createAnonymousAccount();
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        self::assertTrue($result->isUnauthenticated());
+    }
+
+    #[Test]
+    public function owner_can_view_update_delete(): void
+    {
+        $entity = $this->createEntity('workspace', ['account_id' => '42']);
+        $account = $this->createAuthenticatedAccount(42, 'tenant-1');
+
+        foreach (['view', 'update', 'delete'] as $operation) {
+            $result = $this->policy->access($entity, $operation, $account);
+            self::assertTrue($result->isAllowed(), "Owner should be allowed to {$operation}.");
+        }
+    }
+
+    #[Test]
+    public function non_owner_in_same_tenant_is_forbidden(): void
+    {
+        $entity = $this->createEntity('workspace', ['account_id' => '42']);
+        $account = $this->createAuthenticatedAccount(99, 'tenant-1');
+
+        foreach (['view', 'update', 'delete'] as $operation) {
+            $result = $this->policy->access($entity, $operation, $account);
+            self::assertTrue($result->isForbidden(), "Non-owner should be forbidden to {$operation} workspace.");
+        }
+    }
+
+    #[Test]
+    public function non_owner_different_tenant_is_forbidden(): void
+    {
+        $entity = $this->createEntity('workspace', ['account_id' => '42']);
+        $account = $this->createAuthenticatedAccount(99, 'tenant-2');
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        self::assertTrue($result->isForbidden());
+    }
+
+    #[Test]
+    public function create_access_allowed_for_authenticated(): void
+    {
+        $account = $this->createAuthenticatedAccount(1, 'tenant-1');
+
+        $result = $this->policy->createAccess('workspace', 'workspace', $account);
+
+        self::assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function create_access_allowed_without_tenant(): void
+    {
+        $account = $this->createAuthenticatedAccount(1, null);
+
+        $result = $this->policy->createAccess('workspace', 'workspace', $account);
+
+        self::assertTrue($result->isAllowed());
+    }
+
+    #[Test]
+    public function create_access_denied_for_anonymous(): void
+    {
+        $account = $this->createAnonymousAccount();
+
+        $result = $this->policy->createAccess('workspace', 'workspace', $account);
+
+        self::assertTrue($result->isUnauthenticated());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ProjectAccessPolicy`: owner CRUD, tenant read-only, anonymous denied
- Add `RepoAccessPolicy`: same pattern as Project
- Fix `WorkspaceAccessPolicy`: change `owner_id` → `account_id`, restrict to owner-only (no tenant access)

## Test plan
- [x] Tests for owner, tenant, and anonymous access on all three entity types
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)