### PR TITLE
feat(eval): add GraphQL tool schemas for 6 entity CRUD skills (#445)

### DIFF
--- a/evals/schemas/commitment.json
+++ b/evals/schemas/commitment.json
@@ -1,0 +1,55 @@
+[
+  {
+    "name": "createCommitment",
+    "description": "Create a new commitment entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "title": { "type": "string" },
+        "direction": { "type": "string", "enum": ["outbound", "inbound"] },
+        "status": { "type": "string", "enum": ["active", "pending", "completed"] },
+        "due_date": { "type": "string", "format": "date" },
+        "person_uuid": { "type": "string" }
+      },
+      "required": ["title"]
+    }
+  },
+  {
+    "name": "commitmentList",
+    "description": "List commitment entities with optional filters",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string", "enum": ["active", "pending", "completed"] },
+        "direction": { "type": "string", "enum": ["outbound", "inbound"] }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "updateCommitment",
+    "description": "Update an existing commitment entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "status": { "type": "string", "enum": ["active", "pending", "completed"] },
+        "direction": { "type": "string", "enum": ["outbound", "inbound"] },
+        "due_date": { "type": "string", "format": "date" }
+      },
+      "required": ["id"]
+    }
+  },
+  {
+    "name": "deleteCommitment",
+    "description": "Delete a commitment entity by ID",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  }
+]

--- a/evals/schemas/judgment-rule.json
+++ b/evals/schemas/judgment-rule.json
@@ -1,0 +1,51 @@
+[
+  {
+    "name": "createJudgmentRule",
+    "description": "Create a new judgment rule entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "rule_text": { "type": "string" },
+        "context": { "type": "string" },
+        "status": { "type": "string" }
+      },
+      "required": ["rule_text"]
+    }
+  },
+  {
+    "name": "judgmentRuleList",
+    "description": "List judgment rule entities with optional filters",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string" }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "updateJudgmentRule",
+    "description": "Update an existing judgment rule entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "rule_text": { "type": "string" },
+        "context": { "type": "string" },
+        "status": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  },
+  {
+    "name": "deleteJudgmentRule",
+    "description": "Delete a judgment rule entity by ID",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  }
+]

--- a/evals/schemas/new-person.json
+++ b/evals/schemas/new-person.json
@@ -1,0 +1,52 @@
+[
+  {
+    "name": "createPerson",
+    "description": "Create a new person entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string", "format": "email" },
+        "tier": { "type": "string", "enum": ["inner_circle", "active", "contact", "acquaintance"] },
+        "source": { "type": "string" }
+      },
+      "required": ["name"]
+    }
+  },
+  {
+    "name": "personList",
+    "description": "List person entities with optional filters",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "tier": { "type": "string", "enum": ["inner_circle", "active", "contact", "acquaintance"] }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "updatePerson",
+    "description": "Update an existing person entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "email": { "type": "string", "format": "email" },
+        "tier": { "type": "string", "enum": ["inner_circle", "active", "contact", "acquaintance"] }
+      },
+      "required": ["id"]
+    }
+  },
+  {
+    "name": "deletePerson",
+    "description": "Delete a person entity by ID",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  }
+]

--- a/evals/schemas/new-workspace.json
+++ b/evals/schemas/new-workspace.json
@@ -1,0 +1,53 @@
+[
+  {
+    "name": "createWorkspace",
+    "description": "Create a new workspace entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "status": { "type": "string" },
+        "mode": { "type": "string" }
+      },
+      "required": ["name"]
+    }
+  },
+  {
+    "name": "workspaceList",
+    "description": "List workspace entities with optional filters",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string" }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "updateWorkspace",
+    "description": "Update an existing workspace entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "status": { "type": "string" },
+        "mode": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  },
+  {
+    "name": "deleteWorkspace",
+    "description": "Delete a workspace entity by ID",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  }
+]

--- a/evals/schemas/schedule-entry.json
+++ b/evals/schemas/schedule-entry.json
@@ -1,0 +1,55 @@
+[
+  {
+    "name": "createScheduleEntry",
+    "description": "Create a new schedule entry entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "title": { "type": "string" },
+        "starts_at": { "type": "string", "format": "date-time" },
+        "ends_at": { "type": "string", "format": "date-time" },
+        "status": { "type": "string" },
+        "location": { "type": "string" }
+      },
+      "required": ["title"]
+    }
+  },
+  {
+    "name": "scheduleEntryList",
+    "description": "List schedule entry entities with optional filters",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string" }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "updateScheduleEntry",
+    "description": "Update an existing schedule entry entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "starts_at": { "type": "string", "format": "date-time" },
+        "ends_at": { "type": "string", "format": "date-time" },
+        "status": { "type": "string" },
+        "location": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  },
+  {
+    "name": "deleteScheduleEntry",
+    "description": "Delete a schedule entry entity by ID",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  }
+]

--- a/evals/schemas/triage-entry.json
+++ b/evals/schemas/triage-entry.json
@@ -1,0 +1,53 @@
+[
+  {
+    "name": "createTriageEntry",
+    "description": "Create a new triage entry entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "sender_name": { "type": "string" },
+        "sender_email": { "type": "string", "format": "email" },
+        "summary": { "type": "string" },
+        "status": { "type": "string" },
+        "source": { "type": "string" }
+      },
+      "required": ["sender_name", "summary"]
+    }
+  },
+  {
+    "name": "triageEntryList",
+    "description": "List triage entry entities with optional filters",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "status": { "type": "string" }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "updateTriageEntry",
+    "description": "Update an existing triage entry entity",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "sender_name": { "type": "string" },
+        "summary": { "type": "string" },
+        "status": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  },
+  {
+    "name": "deleteTriageEntry",
+    "description": "Delete a triage entry entity by ID",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" }
+      },
+      "required": ["id"]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Created 6 JSON schema files in `evals/schemas/` containing Anthropic tool definitions for the promptfoo eval provider
- Each file defines 4 tools (create, list, update, delete) matching the Messages API format per spec Section 4.3
- Covers: commitment, new-workspace, new-person, schedule-entry, triage-entry, judgment-rule

## Test plan
- [x] All 6 files parse as valid JSON
- [x] Each file contains exactly 4 tool definitions with correct operation names
- [x] Tool schemas match entity fields specified in the design spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)