### PR TITLE
feat(#445): add mock tool responses and LLM-judge rubrics

### DIFF
--- a/evals/mocks/commitment.json
+++ b/evals/mocks/commitment.json
@@ -1,0 +1,28 @@
+{
+  "createCommitment": {
+    "uuid": "mock-commit-001",
+    "title": "Mock commitment",
+    "direction": "outbound",
+    "status": "active",
+    "created_at": "2026-03-22T00:00:00Z"
+  },
+  "commitmentList": {
+    "total": 1,
+    "items": [
+      {
+        "uuid": "mock-commit-001",
+        "title": "Mock commitment",
+        "direction": "outbound",
+        "status": "active"
+      }
+    ]
+  },
+  "updateCommitment": {
+    "uuid": "mock-commit-001",
+    "title": "Mock commitment",
+    "status": "completed"
+  },
+  "deleteCommitment": {
+    "success": true
+  }
+}

--- a/evals/mocks/judgment-rule.json
+++ b/evals/mocks/judgment-rule.json
@@ -1,0 +1,28 @@
+{
+  "createJudgmentRule": {
+    "uuid": "mock-rule-001",
+    "rule_text": "Always prioritize client emails over internal newsletters",
+    "context": "email-triage",
+    "status": "active",
+    "created_at": "2026-03-22T00:00:00Z"
+  },
+  "judgmentRuleList": {
+    "total": 1,
+    "items": [
+      {
+        "uuid": "mock-rule-001",
+        "rule_text": "Always prioritize client emails over internal newsletters",
+        "context": "email-triage",
+        "status": "active"
+      }
+    ]
+  },
+  "updateJudgmentRule": {
+    "uuid": "mock-rule-001",
+    "rule_text": "Always prioritize client emails over internal newsletters",
+    "status": "disabled"
+  },
+  "deleteJudgmentRule": {
+    "success": true
+  }
+}

--- a/evals/mocks/new-person.json
+++ b/evals/mocks/new-person.json
@@ -1,0 +1,30 @@
+{
+  "createPerson": {
+    "uuid": "mock-person-001",
+    "name": "Sarah Chen",
+    "email": "sarah@example.com",
+    "tier": "inner-circle",
+    "source": "manual",
+    "created_at": "2026-03-22T00:00:00Z"
+  },
+  "personList": {
+    "total": 1,
+    "items": [
+      {
+        "uuid": "mock-person-001",
+        "name": "Sarah Chen",
+        "email": "sarah@example.com",
+        "tier": "inner-circle",
+        "source": "manual"
+      }
+    ]
+  },
+  "updatePerson": {
+    "uuid": "mock-person-001",
+    "name": "Sarah Chen",
+    "email": "sarah@newco.com"
+  },
+  "deletePerson": {
+    "success": true
+  }
+}

--- a/evals/mocks/new-workspace.json
+++ b/evals/mocks/new-workspace.json
@@ -1,0 +1,30 @@
+{
+  "createWorkspace": {
+    "uuid": "mock-ws-001",
+    "name": "Mock workspace",
+    "description": "A test workspace for eval runs",
+    "status": "active",
+    "mode": "default",
+    "created_at": "2026-03-22T00:00:00Z"
+  },
+  "workspaceList": {
+    "total": 1,
+    "items": [
+      {
+        "uuid": "mock-ws-001",
+        "name": "Mock workspace",
+        "description": "A test workspace for eval runs",
+        "status": "active",
+        "mode": "default"
+      }
+    ]
+  },
+  "updateWorkspace": {
+    "uuid": "mock-ws-001",
+    "name": "Mock workspace",
+    "status": "archived"
+  },
+  "deleteWorkspace": {
+    "success": true
+  }
+}

--- a/evals/mocks/schedule-entry.json
+++ b/evals/mocks/schedule-entry.json
@@ -1,0 +1,32 @@
+{
+  "createScheduleEntry": {
+    "uuid": "mock-sched-001",
+    "title": "Team standup",
+    "starts_at": "2026-03-23T09:00:00Z",
+    "ends_at": "2026-03-23T09:30:00Z",
+    "status": "scheduled",
+    "location": "Zoom",
+    "created_at": "2026-03-22T00:00:00Z"
+  },
+  "scheduleEntryList": {
+    "total": 1,
+    "items": [
+      {
+        "uuid": "mock-sched-001",
+        "title": "Team standup",
+        "starts_at": "2026-03-23T09:00:00Z",
+        "ends_at": "2026-03-23T09:30:00Z",
+        "status": "scheduled",
+        "location": "Zoom"
+      }
+    ]
+  },
+  "updateScheduleEntry": {
+    "uuid": "mock-sched-001",
+    "title": "Team standup",
+    "status": "cancelled"
+  },
+  "deleteScheduleEntry": {
+    "success": true
+  }
+}

--- a/evals/mocks/triage-entry.json
+++ b/evals/mocks/triage-entry.json
@@ -1,0 +1,31 @@
+{
+  "createTriageEntry": {
+    "uuid": "mock-triage-001",
+    "sender_name": "James Wilson",
+    "sender_email": "james@example.com",
+    "summary": "Partnership proposal for Q3 launch",
+    "status": "pending",
+    "source": "gmail",
+    "created_at": "2026-03-22T00:00:00Z"
+  },
+  "triageEntryList": {
+    "total": 1,
+    "items": [
+      {
+        "uuid": "mock-triage-001",
+        "sender_name": "James Wilson",
+        "sender_email": "james@example.com",
+        "summary": "Partnership proposal for Q3 launch",
+        "status": "pending",
+        "source": "gmail"
+      }
+    ]
+  },
+  "updateTriageEntry": {
+    "uuid": "mock-triage-001",
+    "status": "dismissed"
+  },
+  "deleteTriageEntry": {
+    "success": true
+  }
+}

--- a/evals/rubrics/_base.yaml
+++ b/evals/rubrics/_base.yaml
@@ -1,0 +1,49 @@
+version: "1.0"
+skill: _base
+description: "Shared evaluation criteria for all entity CRUD skills"
+
+criteria:
+  - name: intent-extraction
+    weight: 2
+    description: "Did the skill correctly extract the operation (create/list/update/delete) and entity fields from the user's natural language input?"
+    scoring:
+      5: "Perfect extraction. All fields correct, no hallucinated values."
+      3: "Correct operation detected but one field wrong or missing."
+      1: "Wrong operation or multiple fields incorrect."
+      0: "Complete failure to parse intent."
+
+  - name: confirmation-quality
+    weight: 1
+    description: "Is the confirmation message natural, complete, and showing all relevant fields before the mutation?"
+    scoring:
+      5: "Clear, natural confirmation with all fields displayed."
+      3: "Confirmation present but missing a field or awkwardly phrased."
+      1: "Confirmation present but misleading or incomplete."
+      0: "No confirmation before mutation."
+
+  - name: resolve-first-correctness
+    weight: 2
+    description: "For update/delete, did the skill fetch existing entities before parsing, and correctly match the user's reference?"
+    scoring:
+      5: "Fetched list first, matched correctly, no false splits on conjunctions."
+      3: "Fetched list but matching was imprecise."
+      1: "Parsed the name from input without fetching existing entities."
+      0: "Used the raw input string as the entity identifier."
+
+  - name: error-handling
+    weight: 1
+    description: "When something goes wrong (not found, invalid input, API error), does the skill surface the error clearly and offer alternatives?"
+    scoring:
+      5: "Clear error message, offers specific alternative."
+      3: "Error surfaced but no alternative offered."
+      1: "Error swallowed or vague message."
+      0: "Silent failure or retry without explanation."
+
+  - name: tool-call-correctness
+    weight: 2
+    description: "Did the skill call the correct GraphQL mutation/query with the right arguments?"
+    scoring:
+      5: "Correct operation, correct arguments, correct field values."
+      3: "Correct operation but a field value is wrong or extra fields included."
+      1: "Wrong operation called."
+      0: "No tool call made when one was required."

--- a/evals/rubrics/commitment.yaml
+++ b/evals/rubrics/commitment.yaml
@@ -1,0 +1,13 @@
+version: "1.0"
+skill: commitment
+inherits: _base
+
+criteria:
+  - name: direction-detection
+    weight: 1
+    description: "Did the skill correctly detect outbound vs inbound direction from context clues?"
+    scoring:
+      5: "Correct direction detected from natural language cues (I owe = outbound, they owe = inbound)."
+      3: "Correct direction but only after explicit prompt."
+      1: "Wrong direction assigned."
+      0: "Direction field omitted entirely."

--- a/evals/rubrics/judgment-rule.yaml
+++ b/evals/rubrics/judgment-rule.yaml
@@ -1,0 +1,13 @@
+version: "1.0"
+skill: judgment-rule
+inherits: _base
+
+criteria:
+  - name: filler-stripping
+    weight: 1
+    description: "Did the skill strip filler phrases (from now on, remember that, add a rule to) from the rule text?"
+    scoring:
+      5: "All filler stripped, rule text is clean and actionable."
+      3: "Most filler stripped but one phrase remains."
+      1: "Rule text contains multiple filler phrases."
+      0: "Full user sentence used as rule text."

--- a/evals/rubrics/new-person.yaml
+++ b/evals/rubrics/new-person.yaml
@@ -1,0 +1,5 @@
+version: "1.0"
+skill: new-person
+inherits: _base
+
+criteria: []

--- a/evals/rubrics/new-workspace.yaml
+++ b/evals/rubrics/new-workspace.yaml
@@ -1,0 +1,5 @@
+version: "1.0"
+skill: new-workspace
+inherits: _base
+
+criteria: []

--- a/evals/rubrics/schedule-entry.yaml
+++ b/evals/rubrics/schedule-entry.yaml
@@ -1,0 +1,5 @@
+version: "1.0"
+skill: schedule-entry
+inherits: _base
+
+criteria: []

--- a/evals/rubrics/triage-entry.yaml
+++ b/evals/rubrics/triage-entry.yaml
@@ -1,0 +1,13 @@
+version: "1.0"
+skill: triage-entry
+inherits: _base
+
+criteria:
+  - name: dismiss-vs-delete-distinction
+    weight: 1
+    description: "Did the skill correctly distinguish 'dismiss' (status change to dismissed) from 'delete' (permanent removal)?"
+    scoring:
+      5: "Correctly mapped dismiss to updateTriageEntry with status=dismissed."
+      3: "Mapped dismiss to update but wrong status value."
+      1: "Mapped dismiss to delete operation."
+      0: "Confused dismiss and delete entirely."


### PR DESCRIPTION
## Summary

- Added 6 mock JSON files (`evals/mocks/`) with default tool responses (create, list, update, delete) for all entity CRUD skills: commitment, new-workspace, new-person, schedule-entry, triage-entry, judgment-rule
- Added 7 rubric YAML files (`evals/rubrics/`): shared `_base.yaml` with 5 weighted criteria (intent-extraction, confirmation-quality, resolve-first-correctness, error-handling, tool-call-correctness) plus skill-specific rubrics with extra criteria for commitment (direction-detection), judgment-rule (filler-stripping), and triage-entry (dismiss-vs-delete-distinction)

## Test plan

- [x] All 6 JSON files parse without errors (`python3 -c "import json; json.load(open(...))"`)
- [x] All 7 YAML files parse without errors (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] Structural consistency verified: all mocks have 4 CRUD operations, all list responses include `total`/`items`
- [x] All rubrics have correct `version`, `skill`, `inherits` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)