### PR TITLE
feat(#445): add multi-turn evals for all 6 entity CRUD skills

### DIFF
--- a/.claude/skills/commitment/evals/multi-turn.yaml
+++ b/.claude/skills/commitment/evals/multi-turn.yaml
@@ -1,0 +1,71 @@
+schema_version: "1.0"
+skill: commitment
+entity_type: commitment
+eval_type: multi-turn
+max_turns: 10
+subject_model: sonnet
+judge_model: haiku
+
+tests:
+  - name: pronoun-resolution
+    description: "Create a commitment, then update using pronouns"
+    turns:
+      - input: "I owe Sarah a proposal by Friday"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createCommitment
+          - type: field_extraction
+            field: title
+            should_match: "Send proposal to Sarah"
+          - type: direction_detected
+            direction: outbound
+        mock_response:
+          createCommitment:
+            uuid: "test-mt-001"
+            title: "Send proposal to Sarah"
+            direction: outbound
+            status: active
+            due_date: "2026-03-27"
+      - input: "change its due date to next Monday"
+        operation: update
+        assertions:
+          - type: resolve_first
+          - type: graphql_operation
+            operation: updateCommitment
+        mock_response:
+          updateCommitment:
+            uuid: "test-mt-001"
+            title: "Send proposal to Sarah"
+            direction: outbound
+            status: active
+            due_date: "2026-03-30"
+    rubric: commitment
+    tags: [multi-turn, pronoun-resolution]
+
+  - name: follow-up-delete
+    description: "Create a commitment, then delete referring without full name"
+    turns:
+      - input: "I owe Sarah a proposal by Friday"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createCommitment
+        mock_response:
+          createCommitment:
+            uuid: "test-mt-002"
+            title: "Send proposal to Sarah"
+            direction: outbound
+            status: active
+            due_date: "2026-03-27"
+      - input: "actually, remove that"
+        operation: delete
+        assertions:
+          - type: resolve_first
+          - type: echo_back_required
+            field: title
+        mock_response:
+          deleteCommitment:
+            success: true
+    rubric: commitment
+    tags: [multi-turn, context-preservation]

--- a/.claude/skills/judgment-rule/evals/multi-turn.yaml
+++ b/.claude/skills/judgment-rule/evals/multi-turn.yaml
@@ -1,0 +1,63 @@
+schema_version: "1.0"
+skill: judgment-rule
+entity_type: judgment_rule
+eval_type: multi-turn
+max_turns: 10
+subject_model: sonnet
+judge_model: haiku
+
+tests:
+  - name: pronoun-resolution
+    description: "Create a judgment rule, then update using pronouns"
+    turns:
+      - input: "from now on, always CC the team lead on emails"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createJudgmentRule
+          - type: field_extraction
+            field: rule_text
+            should_match: "CC the team lead on emails"
+        mock_response:
+          createJudgmentRule:
+            uuid: "test-mt-001"
+            rule_text: "Always CC the team lead on emails"
+            status: active
+      - input: "update that rule to include managers too"
+        operation: update
+        assertions:
+          - type: resolve_first
+          - type: graphql_operation
+            operation: updateJudgmentRule
+        mock_response:
+          updateJudgmentRule:
+            uuid: "test-mt-001"
+            rule_text: "Always CC the team lead and managers on emails"
+            status: active
+    rubric: judgment-rule
+    tags: [multi-turn, pronoun-resolution]
+
+  - name: follow-up-delete
+    description: "Create a judgment rule, then delete referring without full name"
+    turns:
+      - input: "from now on, always CC the team lead on emails"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createJudgmentRule
+        mock_response:
+          createJudgmentRule:
+            uuid: "test-mt-002"
+            rule_text: "Always CC the team lead on emails"
+            status: active
+      - input: "actually, remove that"
+        operation: delete
+        assertions:
+          - type: resolve_first
+          - type: echo_back_required
+            field: rule_text
+        mock_response:
+          deleteJudgmentRule:
+            success: true
+    rubric: judgment-rule
+    tags: [multi-turn, context-preservation]

--- a/.claude/skills/new-person/evals/multi-turn.yaml
+++ b/.claude/skills/new-person/evals/multi-turn.yaml
@@ -1,0 +1,65 @@
+schema_version: "1.0"
+skill: new-person
+entity_type: person
+eval_type: multi-turn
+max_turns: 10
+subject_model: sonnet
+judge_model: haiku
+
+tests:
+  - name: pronoun-resolution
+    description: "Create a person, then update using pronouns"
+    turns:
+      - input: "add Sarah Chen, VP of Engineering at Acme"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createPerson
+          - type: field_extraction
+            field: name
+            should_match: "Sarah Chen"
+        mock_response:
+          createPerson:
+            uuid: "test-mt-001"
+            name: "Sarah Chen"
+            title: "VP of Engineering"
+            organization: "Acme"
+      - input: "change her email to sarah@newco.com"
+        operation: update
+        assertions:
+          - type: resolve_first
+          - type: graphql_operation
+            operation: updatePerson
+        mock_response:
+          updatePerson:
+            uuid: "test-mt-001"
+            name: "Sarah Chen"
+            email: "sarah@newco.com"
+    rubric: new-person
+    tags: [multi-turn, pronoun-resolution]
+
+  - name: follow-up-delete
+    description: "Create a person, then delete referring without full name"
+    turns:
+      - input: "add Sarah Chen, VP of Engineering at Acme"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createPerson
+        mock_response:
+          createPerson:
+            uuid: "test-mt-002"
+            name: "Sarah Chen"
+            title: "VP of Engineering"
+            organization: "Acme"
+      - input: "actually, remove that"
+        operation: delete
+        assertions:
+          - type: resolve_first
+          - type: echo_back_required
+            field: name
+        mock_response:
+          deletePerson:
+            success: true
+    rubric: new-person
+    tags: [multi-turn, context-preservation]

--- a/.claude/skills/new-workspace/evals/multi-turn.yaml
+++ b/.claude/skills/new-workspace/evals/multi-turn.yaml
@@ -1,0 +1,60 @@
+schema_version: "1.0"
+skill: new-workspace
+entity_type: workspace
+eval_type: multi-turn
+max_turns: 10
+subject_model: sonnet
+judge_model: haiku
+
+tests:
+  - name: pronoun-resolution
+    description: "Create a workspace, then update using pronouns"
+    turns:
+      - input: "create a workspace for Acme Corp"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createWorkspace
+          - type: field_extraction
+            field: name
+            should_match: "Acme Corp"
+        mock_response:
+          createWorkspace:
+            uuid: "test-mt-001"
+            name: "Acme Corp"
+      - input: "rename it to Acme Corporation"
+        operation: update
+        assertions:
+          - type: resolve_first
+          - type: graphql_operation
+            operation: updateWorkspace
+        mock_response:
+          updateWorkspace:
+            uuid: "test-mt-001"
+            name: "Acme Corporation"
+    rubric: new-workspace
+    tags: [multi-turn, pronoun-resolution]
+
+  - name: follow-up-delete
+    description: "Create a workspace, then delete referring without full name"
+    turns:
+      - input: "create a workspace for Acme Corp"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createWorkspace
+        mock_response:
+          createWorkspace:
+            uuid: "test-mt-002"
+            name: "Acme Corp"
+      - input: "actually, remove that"
+        operation: delete
+        assertions:
+          - type: resolve_first
+          - type: echo_back_required
+            field: name
+        mock_response:
+          deleteWorkspace:
+            success: true
+    rubric: new-workspace
+    tags: [multi-turn, context-preservation]

--- a/.claude/skills/schedule-entry/evals/multi-turn.yaml
+++ b/.claude/skills/schedule-entry/evals/multi-turn.yaml
@@ -1,0 +1,63 @@
+schema_version: "1.0"
+skill: schedule-entry
+entity_type: schedule_entry
+eval_type: multi-turn
+max_turns: 10
+subject_model: sonnet
+judge_model: haiku
+
+tests:
+  - name: pronoun-resolution
+    description: "Create a schedule entry, then update using pronouns"
+    turns:
+      - input: "schedule a standup tomorrow at 9am"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createScheduleEntry
+          - type: field_extraction
+            field: title
+            should_match: "Standup"
+        mock_response:
+          createScheduleEntry:
+            uuid: "test-mt-001"
+            title: "Standup"
+            start_time: "2026-03-22T09:00:00"
+      - input: "move it to 10am"
+        operation: update
+        assertions:
+          - type: resolve_first
+          - type: graphql_operation
+            operation: updateScheduleEntry
+        mock_response:
+          updateScheduleEntry:
+            uuid: "test-mt-001"
+            title: "Standup"
+            start_time: "2026-03-22T10:00:00"
+    rubric: schedule-entry
+    tags: [multi-turn, pronoun-resolution]
+
+  - name: follow-up-delete
+    description: "Create a schedule entry, then delete referring without full name"
+    turns:
+      - input: "schedule a standup tomorrow at 9am"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createScheduleEntry
+        mock_response:
+          createScheduleEntry:
+            uuid: "test-mt-002"
+            title: "Standup"
+            start_time: "2026-03-22T09:00:00"
+      - input: "actually, remove that"
+        operation: delete
+        assertions:
+          - type: resolve_first
+          - type: echo_back_required
+            field: title
+        mock_response:
+          deleteScheduleEntry:
+            success: true
+    rubric: schedule-entry
+    tags: [multi-turn, context-preservation]

--- a/.claude/skills/triage-entry/evals/multi-turn.yaml
+++ b/.claude/skills/triage-entry/evals/multi-turn.yaml
@@ -1,0 +1,66 @@
+schema_version: "1.0"
+skill: triage-entry
+entity_type: triage_entry
+eval_type: multi-turn
+max_turns: 10
+subject_model: sonnet
+judge_model: haiku
+
+tests:
+  - name: pronoun-resolution
+    description: "Create a triage entry, then update using pronouns"
+    turns:
+      - input: "triage this email from Sarah about the proposal"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createTriageEntry
+          - type: field_extraction
+            field: sender_name
+            should_match: "Sarah"
+        mock_response:
+          createTriageEntry:
+            uuid: "test-mt-001"
+            sender_name: "Sarah"
+            subject: "Re: Proposal"
+            status: pending
+      - input: "dismiss it"
+        operation: update
+        assertions:
+          - type: resolve_first
+          - type: graphql_operation
+            operation: updateTriageEntry
+        mock_response:
+          updateTriageEntry:
+            uuid: "test-mt-001"
+            sender_name: "Sarah"
+            subject: "Re: Proposal"
+            status: dismissed
+    rubric: triage-entry
+    tags: [multi-turn, pronoun-resolution]
+
+  - name: follow-up-delete
+    description: "Create a triage entry, then delete referring without full name"
+    turns:
+      - input: "triage this email from Sarah about the proposal"
+        operation: create
+        assertions:
+          - type: graphql_operation
+            operation: createTriageEntry
+        mock_response:
+          createTriageEntry:
+            uuid: "test-mt-002"
+            sender_name: "Sarah"
+            subject: "Re: Proposal"
+            status: pending
+      - input: "actually, remove that"
+        operation: delete
+        assertions:
+          - type: resolve_first
+          - type: echo_back_required
+            field: sender_name
+        mock_response:
+          deleteTriageEntry:
+            success: true
+    rubric: triage-entry
+    tags: [multi-turn, context-preservation]


### PR DESCRIPTION
## Summary
- Adds `multi-turn.yaml` eval files for all 6 entity CRUD skills: commitment, new-workspace, new-person, schedule-entry, triage-entry, judgment-rule
- Each file contains 2 tests: **pronoun-resolution** (create then update via pronoun/partial reference) and **follow-up-delete** (create then delete with "actually, remove that")
- Tests conversation context preservation with `resolve_first` and `echo_back_required` assertions

## Test plan
- [x] All 6 YAML files parse successfully via `python3 -c "import yaml; yaml.safe_load(...)"`
- [ ] Validate with deterministic eval validator when available
- [ ] Run via promptfoo provider once trajectory runner is built

🤖 Generated with [Claude Code](https://claude.com/claude-code)