### PR TITLE
feat(#445): add TrajectorySchemaRule and make validator eval-type-aware

### DIFF
--- a/src/Eval/EvalSchemaValidator.php
+++ b/src/Eval/EvalSchemaValidator.php
@@ -12,6 +12,7 @@ use Claudriel\Eval\Rules\CrossFileRule;
 use Claudriel\Eval\Rules\EvalRule;
 use Claudriel\Eval\Rules\ResolveFirstRule;
 use Claudriel\Eval\Rules\TagConsistencyRule;
+use Claudriel\Eval\Rules\TrajectorySchemaRule;
 use Claudriel\Eval\Rules\UniqueNameRule;
 use Claudriel\Eval\Schema\EvalFileSchema;
 use Claudriel\Eval\Schema\TestCaseSchema;
@@ -41,6 +42,7 @@ final class EvalSchemaValidator
             new AssertionCompatibilityRule,
             new ResolveFirstRule,
             new TagConsistencyRule,
+            new TrajectorySchemaRule,
         ];
         $this->crossFileRules = [
             new CoverageRule,
@@ -85,19 +87,39 @@ final class EvalSchemaValidator
             if (isset($parsed['tests']) && is_array($parsed['tests'])) {
                 $testsScanned += count($parsed['tests']);
 
-                foreach ($parsed['tests'] as $test) {
-                    if (is_array($test)) {
-                        $results = array_merge($results, $this->testCaseSchema->validate($test, $relativePath));
+                $evalType = $parsed['eval_type'] ?? 'basic';
+                $isTrajectory = in_array($evalType, ['trajectory', 'multi-turn'], true);
+
+                if (! $isTrajectory) {
+                    foreach ($parsed['tests'] as $test) {
+                        if (is_array($test)) {
+                            $results = array_merge($results, $this->testCaseSchema->validate($test, $relativePath));
+                        }
                     }
                 }
 
                 foreach ($this->fileRules as $rule) {
+                    if ($isTrajectory && ($rule instanceof AssertionCompatibilityRule || $rule instanceof ResolveFirstRule)) {
+                        continue; // TrajectorySchemaRule handles per-turn validation
+                    }
                     $results = array_merge($results, $rule->validate($parsed, $relativePath));
                 }
 
                 $allFilesBySkill[$skillDir][] = $parsed;
 
-                $ops = array_unique(array_column($parsed['tests'], 'operation'));
+                if ($isTrajectory) {
+                    $ops = [];
+                    foreach ($parsed['tests'] as $test) {
+                        foreach ($test['turns'] ?? [] as $turn) {
+                            if (isset($turn['operation'])) {
+                                $ops[] = $turn['operation'];
+                            }
+                        }
+                    }
+                    $ops = array_unique($ops);
+                } else {
+                    $ops = array_unique(array_column($parsed['tests'], 'operation'));
+                }
                 $operationCoverage[$skillDir] = array_values(array_unique(
                     array_merge($operationCoverage[$skillDir] ?? [], $ops),
                 ));

--- a/src/Eval/Rules/TrajectorySchemaRule.php
+++ b/src/Eval/Rules/TrajectorySchemaRule.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Eval\Rules;
+
+use Claudriel\Eval\Report\ValidationResult;
+use Claudriel\Eval\Schema\AssertionRegistry;
+
+final class TrajectorySchemaRule implements EvalRule
+{
+    private const TRAJECTORY_TYPES = ['trajectory', 'multi-turn'];
+
+    private const VALID_OPERATIONS = ['create', 'list', 'update', 'delete'];
+
+    /** @return list<ValidationResult> */
+    public function validate(array $data, string $file): array
+    {
+        $evalType = $data['eval_type'] ?? null;
+
+        if ($evalType === null || ! in_array($evalType, self::TRAJECTORY_TYPES, true)) {
+            return [];
+        }
+
+        $results = [];
+
+        if (isset($data['max_turns']) && (! is_int($data['max_turns']) || $data['max_turns'] < 1)) {
+            $results[] = ValidationResult::error($file, 'TrajectorySchemaRule', 'max_turns must be a positive integer');
+        }
+
+        foreach ($data['tests'] ?? [] as $test) {
+            $testName = $test['name'] ?? '(unnamed)';
+
+            if (! isset($test['turns']) || ! is_array($test['turns']) || count($test['turns']) === 0) {
+                $results[] = ValidationResult::error($file, 'TrajectorySchemaRule', "Test '$testName' must have a non-empty turns array", $testName);
+
+                continue;
+            }
+
+            if (! isset($test['rubric'])) {
+                $results[] = ValidationResult::error($file, 'TrajectorySchemaRule', "Test '$testName' must have a rubric field", $testName);
+            }
+
+            $turnCount = count($test['turns']);
+            foreach ($test['turns'] as $i => $turn) {
+                if (! isset($turn['input'])) {
+                    $results[] = ValidationResult::error($file, 'TrajectorySchemaRule', "Turn #$i in '$testName' must have an input field", $testName);
+                }
+
+                if (! isset($turn['operation'])) {
+                    $results[] = ValidationResult::error($file, 'TrajectorySchemaRule', "Turn #$i in '$testName' must have an operation field", $testName);
+                } elseif (! in_array($turn['operation'], self::VALID_OPERATIONS, true)) {
+                    $results[] = ValidationResult::error($file, 'TrajectorySchemaRule', "Turn #$i in '$testName' has invalid operation '{$turn['operation']}'", $testName);
+                }
+
+                if ($i < $turnCount - 1 && ! isset($turn['mock_response'])) {
+                    $results[] = ValidationResult::warning($file, 'TrajectorySchemaRule', "Turn #$i in '$testName' has no mock_response (recommended for non-final turns)", $testName);
+                }
+
+                if (isset($turn['operation']) && isset($turn['assertions']) && is_array($turn['assertions'])) {
+                    foreach ($turn['assertions'] as $assertion) {
+                        if (isset($assertion['type']) && ! AssertionRegistry::isValidForOperation($assertion['type'], $turn['operation'])) {
+                            $validOps = AssertionRegistry::get($assertion['type'])['operations'] ?? [];
+                            $results[] = ValidationResult::error(
+                                $file,
+                                'TrajectorySchemaRule',
+                                "Turn #$i assertion type '{$assertion['type']}' not valid for operation '{$turn['operation']}' (valid: ".implode(', ', $validOps).')',
+                                $testName,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        return $results;
+    }
+}

--- a/tests/Unit/Eval/Rules/TrajectorySchemaRuleTest.php
+++ b/tests/Unit/Eval/Rules/TrajectorySchemaRuleTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Eval\Rules;
+
+use Claudriel\Eval\Rules\TrajectorySchemaRule;
+use PHPUnit\Framework\TestCase;
+
+final class TrajectorySchemaRuleTest extends TestCase
+{
+    public function test_valid_trajectory_produces_no_errors(): void
+    {
+        $data = [
+            'eval_type' => 'trajectory',
+            'max_turns' => 10,
+            'tests' => [[
+                'name' => 'lifecycle',
+                'turns' => [
+                    ['input' => 'create a thing', 'operation' => 'create', 'assertions' => [['type' => 'confirmation_shown']], 'mock_response' => ['createThing' => ['uuid' => '1']]],
+                    ['input' => 'show things', 'operation' => 'list', 'assertions' => [['type' => 'graphql_operation', 'operation' => 'thingList', 'mutation' => false]]],
+                ],
+                'rubric' => 'test-skill',
+            ]],
+        ];
+
+        $results = (new TrajectorySchemaRule)->validate($data, 'f.yaml');
+
+        self::assertEmpty($results);
+    }
+
+    public function test_missing_turns_produces_error(): void
+    {
+        $data = [
+            'eval_type' => 'trajectory',
+            'tests' => [[
+                'name' => 'bad-test',
+                'rubric' => 'x',
+            ]],
+        ];
+
+        $results = (new TrajectorySchemaRule)->validate($data, 'f.yaml');
+
+        self::assertNotEmpty($results);
+        self::assertStringContainsString('turns', $results[0]->message);
+    }
+
+    public function test_turn_missing_operation_produces_error(): void
+    {
+        $data = [
+            'eval_type' => 'trajectory',
+            'tests' => [[
+                'name' => 'test-1',
+                'turns' => [
+                    ['input' => 'do something', 'assertions' => [['type' => 'confirmation_shown']]],
+                ],
+                'rubric' => 'x',
+            ]],
+        ];
+
+        $results = (new TrajectorySchemaRule)->validate($data, 'f.yaml');
+
+        self::assertNotEmpty($results);
+        self::assertStringContainsString('operation', $results[0]->message);
+    }
+
+    public function test_missing_rubric_produces_error(): void
+    {
+        $data = [
+            'eval_type' => 'trajectory',
+            'tests' => [[
+                'name' => 'test-1',
+                'turns' => [
+                    ['input' => 'x', 'operation' => 'create', 'assertions' => [['type' => 'confirmation_shown']]],
+                ],
+            ]],
+        ];
+
+        $results = (new TrajectorySchemaRule)->validate($data, 'f.yaml');
+
+        self::assertNotEmpty($results);
+        self::assertStringContainsString('rubric', $results[0]->message);
+    }
+
+    public function test_basic_eval_type_skipped(): void
+    {
+        $data = [
+            'eval_type' => 'basic',
+            'tests' => [['name' => 'test-1', 'operation' => 'create', 'input' => 'x', 'assertions' => [['type' => 'confirmation_shown']]]],
+        ];
+
+        $results = (new TrajectorySchemaRule)->validate($data, 'f.yaml');
+
+        self::assertEmpty($results);
+    }
+
+    public function test_no_eval_type_skipped(): void
+    {
+        $data = [
+            'tests' => [['name' => 'test-1', 'operation' => 'create', 'input' => 'x', 'assertions' => [['type' => 'confirmation_shown']]]],
+        ];
+
+        $results = (new TrajectorySchemaRule)->validate($data, 'f.yaml');
+
+        self::assertEmpty($results);
+    }
+
+    public function test_invalid_max_turns_produces_error(): void
+    {
+        $data = [
+            'eval_type' => 'trajectory',
+            'max_turns' => -1,
+            'tests' => [[
+                'name' => 'test-1',
+                'turns' => [
+                    ['input' => 'x', 'operation' => 'create', 'assertions' => [['type' => 'confirmation_shown']]],
+                ],
+                'rubric' => 'x',
+            ]],
+        ];
+
+        $results = (new TrajectorySchemaRule)->validate($data, 'f.yaml');
+
+        self::assertNotEmpty($results);
+        self::assertStringContainsString('max_turns', $results[0]->message);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `TrajectorySchemaRule` that validates trajectory/multi-turn eval files (turns array, per-turn operation/input, rubric, max_turns, assertion compatibility)
- Updates `EvalSchemaValidator` to detect `eval_type` and skip `TestCaseSchema`, `AssertionCompatibilityRule`, and `ResolveFirstRule` for trajectory files
- Extracts operations from `turns[]` instead of top-level `operation` for trajectory coverage tracking

## Test plan
- [x] 7 new unit tests for TrajectorySchemaRule pass
- [x] All 55 eval unit tests pass (no regressions)
- [x] Full suite passes (663 tests)
- [x] Pint lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)