### PR TITLE
feat(#478): wire TelescopeRequestMiddleware into request lifecycle

### DIFF
--- a/src/Middleware/TelescopeRequestMiddleware.php
+++ b/src/Middleware/TelescopeRequestMiddleware.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Middleware;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Foundation\Attribute\AsMiddleware;
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Foundation\Middleware\HttpMiddlewareInterface;
+use Waaseyaa\Telescope\TelescopeServiceProvider as WaaseyaaTelescopeServiceProvider;
+
+/**
+ * Records HTTP request timing and metadata via Telescope's RequestRecorder.
+ *
+ * Sits at the outermost layer of the middleware pipeline (priority 100) so it
+ * captures total request duration including all inner middleware processing.
+ */
+#[AsMiddleware(pipeline: 'http', priority: 100)]
+final class TelescopeRequestMiddleware implements HttpMiddlewareInterface
+{
+    public function __construct(
+        private readonly WaaseyaaTelescopeServiceProvider $telescope,
+    ) {}
+
+    public function process(Request $request, HttpHandlerInterface $next): Response
+    {
+        $startTime = hrtime(true);
+
+        $response = $next->handle($request);
+
+        $durationMs = (hrtime(true) - $startTime) / 1_000_000;
+
+        $this->recordRequest(
+            method: $request->getMethod(),
+            uri: $request->getPathInfo(),
+            statusCode: $response->getStatusCode(),
+            durationMs: $durationMs,
+            controller: $this->resolveController($request),
+        );
+
+        return $response;
+    }
+
+    public function recordRequest(
+        string $method,
+        string $uri,
+        int $statusCode,
+        float $durationMs,
+        string $controller = '',
+    ): void {
+        $recorder = $this->telescope->getRequestRecorder();
+
+        if ($recorder === null) {
+            return;
+        }
+
+        $recorder->record(
+            method: $method,
+            uri: $uri,
+            statusCode: $statusCode,
+            duration: $durationMs,
+            controller: $controller,
+        );
+    }
+
+    private function resolveController(Request $request): string
+    {
+        $controller = $request->attributes->get('_controller', '');
+
+        return is_string($controller) ? $controller : '';
+    }
+}

--- a/src/Provider/TelescopeServiceProvider.php
+++ b/src/Provider/TelescopeServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Claudriel\Provider;
 
+use Claudriel\Middleware\TelescopeRequestMiddleware;
+use Waaseyaa\Entity\EntityTypeManager;
 use Waaseyaa\Foundation\ServiceProvider\ServiceProvider;
 use Waaseyaa\Telescope\Storage\SqliteTelescopeStore;
 use Waaseyaa\Telescope\TelescopeServiceProvider as WaaseyaaTelescopeServiceProvider;
@@ -26,6 +28,21 @@ final class TelescopeServiceProvider extends ServiceProvider
         // Event recording: entity events use Symfony EventDispatcher but providers
         // lack a registration point for generic listeners. Wire QueryRecorder and
         // EventRecorder here when those framework hooks land.
+        //
+        // CacheRecorder: waaseyaa/telescope provides CacheRecorder with
+        // recordHit/recordMiss/recordSet/recordForget methods. However,
+        // waaseyaa/cache does not emit events on cache operations (it only has
+        // invalidation listeners). CacheRecorder wiring is BLOCKED until
+        // waaseyaa/cache emits operation events or app-level cache decorators
+        // (e.g. CachedDayBriefAssembler) are instrumented to call CacheRecorder
+        // directly.
+    }
+
+    public function middleware(EntityTypeManager $entityTypeManager): array
+    {
+        return [
+            new TelescopeRequestMiddleware($this->getTelescope()),
+        ];
     }
 
     public function getTelescope(): WaaseyaaTelescopeServiceProvider

--- a/tests/Unit/Middleware/TelescopeRequestMiddlewareTest.php
+++ b/tests/Unit/Middleware/TelescopeRequestMiddlewareTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Middleware;
+
+use Claudriel\Middleware\TelescopeRequestMiddleware;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Waaseyaa\Foundation\Middleware\HttpHandlerInterface;
+use Waaseyaa\Telescope\Storage\SqliteTelescopeStore;
+use Waaseyaa\Telescope\TelescopeServiceProvider as WaaseyaaTelescopeServiceProvider;
+
+final class TelescopeRequestMiddlewareTest extends TestCase
+{
+    public function test_middleware_records_request(): void
+    {
+        $store = SqliteTelescopeStore::createInMemory();
+        $telescope = new WaaseyaaTelescopeServiceProvider(
+            config: [
+                'enabled' => true,
+                'record' => ['requests' => true],
+                'ignore_paths' => [],
+            ],
+            store: $store,
+        );
+
+        $middleware = new TelescopeRequestMiddleware($telescope);
+        $middleware->recordRequest('GET', '/brief', 200, 42.5, 'DayBriefController');
+
+        $entries = $store->query('request', 10);
+        self::assertNotEmpty($entries);
+        self::assertSame('request', $entries[0]->type);
+
+        $data = $entries[0]->data;
+        self::assertSame('GET', $data['method']);
+        self::assertSame('/brief', $data['uri']);
+        self::assertSame(200, $data['status_code']);
+        self::assertSame(42.5, $data['duration']);
+        self::assertSame('DayBriefController', $data['controller']);
+    }
+
+    public function test_middleware_wraps_request_lifecycle(): void
+    {
+        $store = SqliteTelescopeStore::createInMemory();
+        $telescope = new WaaseyaaTelescopeServiceProvider(
+            config: [
+                'enabled' => true,
+                'record' => ['requests' => true],
+                'ignore_paths' => [],
+            ],
+            store: $store,
+        );
+
+        $middleware = new TelescopeRequestMiddleware($telescope);
+        $request = Request::create('/brief', 'GET');
+
+        $handler = new class implements HttpHandlerInterface
+        {
+            public function handle(Request $request): Response
+            {
+                return new Response('OK', 200);
+            }
+        };
+
+        $response = $middleware->process($request, $handler);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('OK', $response->getContent());
+
+        $entries = $store->query('request', 10);
+        self::assertNotEmpty($entries);
+        self::assertSame('GET', $entries[0]->data['method']);
+        self::assertSame('/brief', $entries[0]->data['uri']);
+        self::assertSame(200, $entries[0]->data['status_code']);
+        self::assertGreaterThan(0.0, $entries[0]->data['duration']);
+    }
+
+    public function test_middleware_skips_when_telescope_disabled(): void
+    {
+        $store = SqliteTelescopeStore::createInMemory();
+        $telescope = new WaaseyaaTelescopeServiceProvider(
+            config: [
+                'enabled' => false,
+                'record' => ['requests' => true],
+            ],
+            store: $store,
+        );
+
+        $middleware = new TelescopeRequestMiddleware($telescope);
+        $middleware->recordRequest('GET', '/brief', 200, 10.0);
+
+        $entries = $store->query('request', 10);
+        self::assertEmpty($entries);
+    }
+
+    public function test_middleware_respects_ignore_paths(): void
+    {
+        $store = SqliteTelescopeStore::createInMemory();
+        $telescope = new WaaseyaaTelescopeServiceProvider(
+            config: [
+                'enabled' => true,
+                'record' => ['requests' => true],
+                'ignore_paths' => ['/health'],
+            ],
+            store: $store,
+        );
+
+        $middleware = new TelescopeRequestMiddleware($telescope);
+        $middleware->recordRequest('GET', '/health', 200, 1.0);
+
+        $entries = $store->query('request', 10);
+        self::assertEmpty($entries);
+    }
+}


### PR DESCRIPTION
Created TelescopeRequestMiddleware (priority 100) to capture request timing via Telescope RequestRecorder. Wired into TelescopeServiceProvider middleware. CacheRecorder blocked: waaseyaa/cache lacks operation event hooks.