### PR TITLE
feat(#445): add eval report generator

### DIFF
--- a/agent/eval_report.py
+++ b/agent/eval_report.py
@@ -1,0 +1,81 @@
+"""Eval report generation in JSON and markdown formats."""
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass
+class TestResult:
+    name: str
+    score: float
+    reason: str
+
+
+@dataclass
+class SkillResult:
+    tests_run: int
+    tests_passed: int
+    average_score: float
+    failures: list[TestResult] = field(default_factory=list)
+
+
+def generate_report(results: dict[str, SkillResult], mode: str = "llm-judge") -> dict[str, Any]:
+    """Generate a structured report from skill results."""
+    total_run = sum(r.tests_run for r in results.values())
+    total_passed = sum(r.tests_passed for r in results.values())
+
+    skills_data = {}
+    for name, result in sorted(results.items()):
+        skills_data[name] = {
+            "tests_run": result.tests_run,
+            "tests_passed": result.tests_passed,
+            "average_score": round(result.average_score, 2),
+            "failures": [
+                {"test": f.name, "score": f.score, "reason": f.reason}
+                for f in result.failures
+            ],
+        }
+
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "mode": mode,
+        "skills": skills_data,
+        "totals": {
+            "tests_run": total_run,
+            "tests_passed": total_passed,
+            "pass_rate": round(total_passed / total_run, 3) if total_run > 0 else 0.0,
+        },
+    }
+
+
+def format_markdown(report: dict[str, Any]) -> str:
+    """Format a report as markdown for PR comments."""
+    lines = [
+        f"## Skill Eval Report ({report['mode']})",
+        "",
+        f"**Total:** {report['totals']['tests_passed']}/{report['totals']['tests_run']} passed "
+        f"({report['totals']['pass_rate'] * 100:.1f}%)",
+        "",
+        "| Skill | Passed | Score | Status |",
+        "|-------|--------|-------|--------|",
+    ]
+
+    for name, data in report["skills"].items():
+        status = "pass" if data["tests_passed"] == data["tests_run"] else "FAIL"
+        lines.append(
+            f"| {name} | {data['tests_passed']}/{data['tests_run']} "
+            f"| {data['average_score']:.1f} | {status} |"
+        )
+
+    # Show failures
+    all_failures = []
+    for name, data in report["skills"].items():
+        for f in data["failures"]:
+            all_failures.append((name, f))
+
+    if all_failures:
+        lines.extend(["", "### Failures", ""])
+        for skill, failure in all_failures:
+            lines.append(f"- **{skill}/{failure['test']}** (score: {failure['score']}): {failure['reason']}")
+
+    return "\n".join(lines)

--- a/agent/tests/test_eval_report.py
+++ b/agent/tests/test_eval_report.py
@@ -1,0 +1,53 @@
+"""Tests for eval report generation."""
+import json
+from eval_report import generate_report, format_markdown, SkillResult, TestResult
+
+
+def test_generate_report_structure():
+    results = {
+        "commitment": SkillResult(
+            tests_run=10,
+            tests_passed=9,
+            average_score=4.2,
+            failures=[TestResult(name="edge-case", score=1.0, reason="missed")],
+        ),
+    }
+    report = generate_report(results)
+    assert report["totals"]["tests_run"] == 10
+    assert report["totals"]["tests_passed"] == 9
+    assert report["totals"]["pass_rate"] == 0.9
+    assert "commitment" in report["skills"]
+
+
+def test_generate_report_empty():
+    report = generate_report({})
+    assert report["totals"]["tests_run"] == 0
+    assert report["totals"]["pass_rate"] == 0.0
+
+
+def test_format_markdown_includes_summary():
+    results = {
+        "commitment": SkillResult(tests_run=5, tests_passed=5, average_score=4.5, failures=[]),
+    }
+    report = generate_report(results)
+    md = format_markdown(report)
+    assert "commitment" in md
+    assert "5/5" in md or "100%" in md
+
+
+def test_format_markdown_shows_failures():
+    results = {
+        "commitment": SkillResult(
+            tests_run=3,
+            tests_passed=1,
+            average_score=2.0,
+            failures=[
+                TestResult(name="test-a", score=1.0, reason="bad"),
+                TestResult(name="test-b", score=0.0, reason="wrong"),
+            ],
+        ),
+    }
+    report = generate_report(results)
+    md = format_markdown(report)
+    assert "test-a" in md
+    assert "test-b" in md


### PR DESCRIPTION
## Summary
- Add `agent/eval_report.py` with `TestResult`/`SkillResult` dataclasses, `generate_report()` and `format_markdown()` functions
- Add `agent/tests/test_eval_report.py` with 4 unit tests covering report structure, empty results, markdown summary, and failure details
- Part of the eval framework (#445/#446)

## Test plan
- [x] `python3 -m pytest tests/test_eval_report.py -v` — 4/4 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)