### PR TITLE
feat(#445): add LLM judge scoring module

### DIFF
--- a/agent/eval_judge.py
+++ b/agent/eval_judge.py
@@ -1,0 +1,115 @@
+"""LLM judge for scoring skill eval outputs."""
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+JUDGE_MODEL = "claude-haiku-4-5-20251001"
+
+
+@dataclass
+class AssertionScore:
+    assertion: str
+    score: float
+    reason: str
+
+
+@dataclass
+class JudgeScore:
+    scores: list[AssertionScore] = field(default_factory=list)
+    overall: float = 0.0
+    error: str | None = None
+
+
+def build_judge_prompt(
+    skill_name: str,
+    user_input: str,
+    response_text: str,
+    assertions: list[dict[str, Any]],
+) -> str:
+    """Build the judge evaluation prompt."""
+    rubric_lines = []
+    for i, assertion in enumerate(assertions, 1):
+        parts = [f"{i}. Type: {assertion['type']}"]
+        for key, value in assertion.items():
+            if key != "type":
+                parts.append(f"   {key}: {value}")
+        rubric_lines.append("\n".join(parts))
+
+    rubric = "\n".join(rubric_lines)
+
+    return f"""You are evaluating a Claudriel skill response for correctness and quality.
+
+Skill: {skill_name}
+User input: {user_input}
+
+Skill response:
+{response_text}
+
+Evaluate against these criteria:
+{rubric}
+
+For each criterion, score 0-5:
+0 = completely wrong or missing
+1 = attempted but mostly wrong
+2 = partially correct with significant issues
+3 = mostly correct with minor issues
+4 = correct with trivial issues
+5 = perfect
+
+Return ONLY valid JSON (no other text):
+{{"scores": [{{"assertion": "<type>", "score": <N>, "reason": "<brief>"}}], "overall": <N.N>}}"""
+
+
+def parse_judge_response(raw: str) -> JudgeScore:
+    """Parse judge response, extracting JSON from potential surrounding text."""
+    # Try direct parse first
+    try:
+        data = json.loads(raw.strip())
+        return _build_score(data)
+    except json.JSONDecodeError:
+        pass
+
+    # Try to find JSON in text
+    match = re.search(r'\{.*"scores".*"overall".*\}', raw, re.DOTALL)
+    if match:
+        try:
+            data = json.loads(match.group())
+            return _build_score(data)
+        except json.JSONDecodeError:
+            pass
+
+    return JudgeScore(error=f"Could not parse judge response: {raw[:200]}")
+
+
+def _build_score(data: dict) -> JudgeScore:
+    scores = []
+    for s in data.get("scores", []):
+        scores.append(AssertionScore(
+            assertion=s.get("assertion", ""),
+            score=float(s.get("score", 0)),
+            reason=s.get("reason", ""),
+        ))
+    return JudgeScore(scores=scores, overall=float(data.get("overall", 0.0)))
+
+
+def judge_response(
+    skill_name: str,
+    user_input: str,
+    response_text: str,
+    assertions: list[dict[str, Any]],
+    model: str = JUDGE_MODEL,
+) -> JudgeScore:
+    """Send a skill response to the LLM judge for scoring."""
+    import anthropic
+    client = anthropic.Anthropic()
+    prompt = build_judge_prompt(skill_name, user_input, response_text, assertions)
+
+    response = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    raw = response.content[0].text
+    return parse_judge_response(raw)

--- a/agent/tests/test_eval_judge.py
+++ b/agent/tests/test_eval_judge.py
@@ -1,0 +1,60 @@
+"""Tests for LLM judge prompt construction and score parsing."""
+import json
+from eval_judge import build_judge_prompt, parse_judge_response, JudgeScore
+
+
+def test_build_judge_prompt_includes_skill_and_input():
+    prompt = build_judge_prompt(
+        skill_name="commitment",
+        user_input="I owe Sarah a proposal",
+        response_text="I'll create a commitment...",
+        assertions=[{"type": "confirmation_shown"}, {"type": "direction_detected", "direction": "outbound"}],
+    )
+    assert "commitment" in prompt
+    assert "I owe Sarah a proposal" in prompt
+    assert "I'll create a commitment" in prompt
+    assert "confirmation_shown" in prompt
+    assert "direction_detected" in prompt
+
+
+def test_build_judge_prompt_formats_assertions_as_rubric():
+    prompt = build_judge_prompt(
+        skill_name="test",
+        user_input="test input",
+        response_text="test response",
+        assertions=[
+            {"type": "field_extraction", "field": "title", "should_match": "Proposal"},
+            {"type": "confirmation_shown"},
+        ],
+    )
+    assert "field_extraction" in prompt
+    assert "title" in prompt
+    assert "Proposal" in prompt
+
+
+def test_parse_judge_response_valid_json():
+    raw = json.dumps({
+        "scores": [
+            {"assertion": "confirmation_shown", "score": 5, "reason": "Clear confirmation"},
+            {"assertion": "direction_detected", "score": 4, "reason": "Correctly outbound"},
+        ],
+        "overall": 4.5,
+    })
+    result = parse_judge_response(raw)
+    assert len(result.scores) == 2
+    assert result.scores[0].score == 5
+    assert result.overall == 4.5
+
+
+def test_parse_judge_response_extracts_json_from_text():
+    """Judge may include text around the JSON."""
+    raw = 'Here is my evaluation:\n{"scores": [{"assertion": "a", "score": 3, "reason": "ok"}], "overall": 3.0}\nDone.'
+    result = parse_judge_response(raw)
+    assert result.overall == 3.0
+
+
+def test_parse_judge_response_invalid():
+    """Garbage input returns a zero-score result."""
+    result = parse_judge_response("this is not json at all")
+    assert result.overall == 0.0
+    assert result.error is not None


### PR DESCRIPTION
## Summary
- Add `agent/eval_judge.py` with LLM judge scoring: prompt builder, response parser, and Claude API caller
- Add `agent/tests/test_eval_judge.py` with 5 unit tests covering prompt construction and JSON parsing (no API calls)
- Lazy-import `anthropic` SDK so tests run without the dependency installed

## Test plan
- [x] `python -m pytest tests/test_eval_judge.py -v` passes all 5 tests
- [ ] Verify `judge_response()` works with a live API key (manual, not in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)