### PR TITLE
feat(#445): add eval schema validator and Python dependencies

### DIFF
--- a/agent/eval_schema.py
+++ b/agent/eval_schema.py
@@ -1,0 +1,91 @@
+"""YAML schema validation for eval files."""
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VALID_ASSERTION_TYPES = {
+    "field_extraction",
+    "direction_detected",
+    "confirmation_shown",
+    "graphql_operation",
+    "table_presented",
+    "filter_applied",
+    "resolve_first",
+    "disambiguation",
+    "error_surfaced",
+    "before_after_shown",
+    "asks_for_field",
+    "no_conjunction_split",
+    "echo_back_required",
+    "offers_alternative",
+}
+
+REQUIRED_TOP_LEVEL = {"schema_version", "skill", "tests"}
+REQUIRED_TEST_FIELDS = {"name", "operation", "input"}
+
+
+@dataclass
+class ValidationError:
+    file: str
+    message: str
+    line: int | None = None
+
+
+def validate_eval_file(data: dict[str, Any], filename: str) -> list[ValidationError]:
+    """Validate a parsed eval YAML structure. Returns list of errors (empty = valid)."""
+    errors: list[ValidationError] = []
+
+    for field in REQUIRED_TOP_LEVEL:
+        if field not in data:
+            errors.append(ValidationError(filename, f"Missing required field: {field}"))
+
+    tests = data.get("tests", [])
+    if not isinstance(tests, list):
+        errors.append(ValidationError(filename, "tests must be a list"))
+        return errors
+
+    seen_names: set[str] = set()
+    for i, test in enumerate(tests):
+        if not isinstance(test, dict):
+            errors.append(ValidationError(filename, f"Test {i} must be a mapping"))
+            continue
+
+        for field in REQUIRED_TEST_FIELDS:
+            if field not in test:
+                errors.append(ValidationError(filename, f"Test {i}: missing required field: {field}"))
+
+        name = test.get("name", "")
+        if name in seen_names:
+            errors.append(ValidationError(filename, f"Duplicate test name: {name}"))
+        seen_names.add(name)
+
+        for assertion in test.get("assertions", []):
+            if not isinstance(assertion, dict):
+                continue
+            atype = assertion.get("type", "")
+            if atype not in VALID_ASSERTION_TYPES:
+                errors.append(ValidationError(filename, f"Test '{name}': unknown assertion type: {atype}"))
+
+    return errors
+
+
+def load_and_validate(path: Path) -> list[ValidationError]:
+    """Load a YAML file and validate it."""
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        return [ValidationError(str(path), "File must contain a YAML mapping")]
+    return validate_eval_file(data, path.name)
+
+
+def discover_eval_files(skills_dir: Path) -> list[Path]:
+    """Find all eval YAML files under skill directories."""
+    files: list[Path] = []
+    for eval_dir in sorted(skills_dir.glob("*/evals")):
+        for yaml_file in sorted(eval_dir.glob("*.yaml")):
+            files.append(yaml_file)
+        for yml_file in sorted(eval_dir.glob("*.yml")):
+            files.append(yml_file)
+    return files

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,2 +1,3 @@
 anthropic>=0.40.0
 httpx>=0.27.0
+pyyaml>=6.0

--- a/agent/tests/test_eval_schema.py
+++ b/agent/tests/test_eval_schema.py
@@ -1,0 +1,94 @@
+"""Tests for eval YAML schema validation."""
+from eval_schema import validate_eval_file, ValidationError, discover_eval_files
+
+
+def test_valid_basic_eval():
+    """A well-formed basic eval file passes validation."""
+    data = {
+        "schema_version": "1.0",
+        "skill": "commitment",
+        "entity_type": "commitment",
+        "tests": [
+            {
+                "name": "create-simple",
+                "operation": "create",
+                "input": "I owe Sarah a proposal",
+                "assertions": [
+                    {"type": "confirmation_shown"}
+                ],
+            }
+        ],
+    }
+    errors = validate_eval_file(data, "basic.yaml")
+    assert errors == []
+
+
+def test_missing_required_fields():
+    """Missing schema_version or skill fails."""
+    data = {"tests": []}
+    errors = validate_eval_file(data, "bad.yaml")
+    assert any("schema_version" in e.message for e in errors)
+    assert any("skill" in e.message for e in errors)
+
+
+def test_invalid_assertion_type():
+    """Unknown assertion type is flagged."""
+    data = {
+        "schema_version": "1.0",
+        "skill": "commitment",
+        "entity_type": "commitment",
+        "tests": [
+            {
+                "name": "bad-assertion",
+                "operation": "create",
+                "input": "test",
+                "assertions": [{"type": "nonexistent_type"}],
+            }
+        ],
+    }
+    errors = validate_eval_file(data, "test.yaml")
+    assert any("nonexistent_type" in e.message for e in errors)
+
+
+def test_duplicate_test_names():
+    """Duplicate test names within a file are flagged."""
+    data = {
+        "schema_version": "1.0",
+        "skill": "commitment",
+        "entity_type": "commitment",
+        "tests": [
+            {"name": "dupe", "operation": "create", "input": "a", "assertions": []},
+            {"name": "dupe", "operation": "list", "input": "b", "assertions": []},
+        ],
+    }
+    errors = validate_eval_file(data, "test.yaml")
+    assert any("duplicate" in e.message.lower() for e in errors)
+
+
+def test_test_missing_required_fields():
+    """Test case missing name, operation, or input is flagged."""
+    data = {
+        "schema_version": "1.0",
+        "skill": "commitment",
+        "entity_type": "commitment",
+        "tests": [{"assertions": []}],
+    }
+    errors = validate_eval_file(data, "test.yaml")
+    assert any("name" in e.message for e in errors)
+
+
+def test_discover_eval_files(tmp_path):
+    """discover_eval_files finds YAML files in skill eval dirs."""
+    # Create a fixture skills directory with eval files
+    skill_dir = tmp_path / "commitment" / "evals"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "basic.yaml").write_text("schema_version: '1.0'\n")
+    (skill_dir / "advanced.yml").write_text("schema_version: '1.0'\n")
+
+    # Also create a non-eval dir that should be ignored
+    (tmp_path / "commitment" / "other").mkdir()
+    (tmp_path / "commitment" / "other" / "ignore.yaml").write_text("")
+
+    files = discover_eval_files(tmp_path)
+    assert len(files) == 2
+    assert all(f.suffix in (".yaml", ".yml") for f in files)


### PR DESCRIPTION
## Summary
- Add `agent/eval_schema.py` with YAML schema validation for eval files (validates required fields, assertion types, duplicate test names)
- Add `agent/tests/test_eval_schema.py` with 6 unit tests covering valid files, missing fields, invalid assertions, and file discovery
- Add `pyyaml>=6.0` to `agent/requirements.txt`

## Test plan
- [x] All 6 eval schema tests pass
- [ ] CI runs successfully

Closes #445 (partial: schema validator module only)

Generated with [Claude Code](https://claude.com/claude-code)