### PR TITLE
feat(#510,#435): update admin GraphQL adapter fields

### DIFF
--- a/frontend/admin/app/host/claudrielAdapter.ts
+++ b/frontend/admin/app/host/claudrielAdapter.ts
@@ -12,14 +12,19 @@ const LABEL_FIELDS: Record<string, string> = {
   triage_entry: 'sender_name',
   project: 'name',
   judgment_rule: 'rule_text',
+  repo: 'name',
 }
 
 /** Fields to request per GraphQL entity type. */
 const GRAPHQL_FIELDS: Record<string, string> = {
   commitment: 'uuid title status confidence direction due_date person_uuid source tenant_id created_at updated_at',
   person: 'uuid name email tier source tenant_id latest_summary last_interaction_at last_inbox_category created_at updated_at',
-  project: 'uuid name description status metadata settings context account_id tenant_id created_at updated_at',
-  workspace: 'uuid name description account_id tenant_id metadata repo_path repo_url branch codex_model last_commit_hash ci_status project_id mode status created_at updated_at',
+  project: 'uuid name description status account_id tenant_id created_at updated_at',
+  workspace: 'uuid name description saved_context account_id tenant_id mode status created_at updated_at',
+  repo: 'uuid owner name full_name url default_branch local_path account_id tenant_id created_at updated_at',
+  project_repo: 'uuid project_uuid repo_uuid created_at',
+  workspace_project: 'uuid workspace_uuid project_uuid created_at',
+  workspace_repo: 'uuid workspace_uuid repo_uuid is_active created_at',
   schedule_entry: 'uuid title starts_at ends_at notes source status external_id calendar_id recurring_series_id tenant_id created_at updated_at',
   triage_entry: 'uuid sender_name sender_email summary status source tenant_id occurred_at external_id content_hash raw_payload created_at updated_at',
   judgment_rule: 'uuid rule_text context source confidence application_count last_applied_at status tenant_id created_at updated_at',


### PR DESCRIPTION
## Summary
- Remove obsolete project fields (metadata, settings, context) and workspace fields (metadata, repo_path, repo_url, branch, codex_model, last_commit_hash, ci_status, project_id) from GRAPHQL_FIELDS
- Add saved_context to workspace fields
- Register four new entity types in GRAPHQL_FIELDS: repo, project_repo, workspace_project, workspace_repo
- Add repo: name to LABEL_FIELDS

## Test plan
- [x] Vitest unit tests pass (19/20 files; 1 pre-existing failure in useSchema.test.ts unrelated to this change)
- [x] Pre-push hooks pass (PHPStan, Pint, PHPUnit, Python tests)

Generated with [Claude Code](https://claude.com/claude-code)