### PR TITLE
fix(#491,#495): workspace root env var and ownership

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ CLAUDRIEL_TIMEZONE=America/Toronto
 # Project root override (auto-detected when unset)
 # CLAUDRIEL_PROJECT_ROOT=/srv/claudriel
 
+# Workspace root directory for repo clones (defaults to <project>/workspaces)
+# CLAUDRIEL_WORKSPACE_ROOT=/srv/claudriel/workspaces
+
 # App base URL (used for OAuth redirects and email verification links)
 CLAUDRIEL_APP_URL=https://claudriel.northcloud.one
 

--- a/src/Access/WorkspaceAccessPolicy.php
+++ b/src/Access/WorkspaceAccessPolicy.php
@@ -31,9 +31,7 @@ final class WorkspaceAccessPolicy implements AccessPolicyInterface
             return AccessResult::allowed('Admin permission.');
         }
 
-        $accountId = (string) $account->id();
-
-        if ($entity->get('account_id') !== $accountId) {
+        if (! $this->isOwner($entity, $account)) {
             return AccessResult::forbidden('Workspaces are personal. Only the owner can access.');
         }
 
@@ -50,5 +48,34 @@ final class WorkspaceAccessPolicy implements AccessPolicyInterface
         }
 
         return AccessResult::allowed('Authenticated user can create workspaces.');
+    }
+
+    /**
+     * Match workspace owner by numeric ID or UUID.
+     *
+     * The agent subprocess creates workspaces with account_id set to the
+     * account UUID (from the HMAC token), while the admin SPA session
+     * resolves $account->id() as the numeric entity ID. Accept either.
+     */
+    private function isOwner(EntityInterface $entity, AccountInterface $account): bool
+    {
+        $storedId = $entity->get('account_id');
+        if ($storedId === null || $storedId === '') {
+            return false;
+        }
+
+        $storedId = (string) $storedId;
+
+        // Match numeric entity ID
+        if ($storedId === (string) $account->id()) {
+            return true;
+        }
+
+        // Match UUID (agent subprocess path)
+        if ($account instanceof AuthenticatedAccount && $storedId === $account->getUuid()) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Controller/InternalWorkspaceController.php
+++ b/src/Controller/InternalWorkspaceController.php
@@ -82,7 +82,8 @@ final class InternalWorkspaceController
 
     public function create(array $params = [], array $query = [], ?AccountInterface $account = null, ?Request $httpRequest = null): SsrResponse
     {
-        if ($this->authenticate($httpRequest) === null) {
+        $authenticatedId = $this->authenticate($httpRequest);
+        if ($authenticatedId === null) {
             return $this->jsonError('Unauthorized', 401);
         }
 
@@ -106,6 +107,7 @@ final class InternalWorkspaceController
             'description' => $description,
             'mode' => $mode,
             'status' => 'active',
+            'account_id' => $authenticatedId,
             'tenant_id' => $this->resolveTenantId($httpRequest),
         ]);
         $this->workspaceRepo->save($workspace);

--- a/tests/Feature/Access/WorkspaceAccessPolicyTest.php
+++ b/tests/Feature/Access/WorkspaceAccessPolicyTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Claudriel\Tests\Feature\Access;
 
+use Claudriel\Access\AuthenticatedAccount;
 use Claudriel\Access\WorkspaceAccessPolicy;
+use Claudriel\Entity\Account;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -102,5 +104,35 @@ final class WorkspaceAccessPolicyTest extends TestCase
         $result = $this->policy->createAccess('workspace', 'workspace', $account);
 
         self::assertTrue($result->isUnauthenticated());
+    }
+
+    #[Test]
+    public function owner_matched_by_uuid_from_agent_tool(): void
+    {
+        $accountUuid = 'a1b2c3d4-e5f6-4789-abcd-ef0123456789';
+        $entity = $this->createEntity('workspace', ['account_id' => $accountUuid]);
+
+        // Simulate AuthenticatedAccount where id() returns numeric but getUuid() matches
+        $account = new AuthenticatedAccount(new Account([
+            'aid' => 42,
+            'uuid' => $accountUuid,
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+        ]));
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        self::assertTrue($result->isAllowed(), 'Owner should be matched by UUID when account_id stores a UUID.');
+    }
+
+    #[Test]
+    public function null_account_id_denies_access(): void
+    {
+        $entity = $this->createEntity('workspace', ['account_id' => null]);
+        $account = $this->createAuthenticatedAccount(42, 'tenant-1');
+
+        $result = $this->policy->access($entity, 'view', $account);
+
+        self::assertTrue($result->isForbidden(), 'Workspace without account_id should deny access.');
     }
 }

--- a/tests/Unit/Controller/InternalWorkspaceControllerTest.php
+++ b/tests/Unit/Controller/InternalWorkspaceControllerTest.php
@@ -103,6 +103,11 @@ final class InternalWorkspaceControllerTest extends TestCase
         self::assertSame('persistent', $data['mode']);
         self::assertArrayHasKey('uuid', $data);
         self::assertArrayHasKey('created_at', $data);
+
+        // Verify account_id was set from the HMAC token (#495)
+        $workspaces = $this->repo->findBy(['uuid' => $data['uuid']]);
+        self::assertCount(1, $workspaces);
+        self::assertSame('acct-123', $workspaces[0]->get('account_id'));
     }
 
     public function test_create_rejects_missing_name(): void


### PR DESCRIPTION
## Summary
- **#491**: Add CLAUDRIEL_WORKSPACE_ROOT to .env.example for production workspace path config
- **#495**: Set account_id on agent-created workspaces and update WorkspaceAccessPolicy to match by UUID, fixing invisible workspaces

## Test plan
- [x] 703 tests pass (2 new), 2131 assertions
- [ ] Manual: deploy to staging, create workspace via chat, verify in admin SPA