### PR TITLE
feat(#574): add CodeTask entity, runner, and CLI command

### DIFF
--- a/src/Command/CodeTaskRunCommand.php
+++ b/src/Command/CodeTaskRunCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Command;
+
+use Claudriel\Domain\CodeTask\CodeTaskRunner;
+use Claudriel\Domain\Git\GitRepositoryManager;
+use Claudriel\Entity\CodeTask;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+
+#[AsCommand(name: 'claudriel:code-task:run', description: 'Execute a queued code task via Claude Code CLI')]
+final class CodeTaskRunCommand extends Command
+{
+    public function __construct(
+        private readonly EntityRepositoryInterface $codeTaskRepo,
+        private readonly CodeTaskRunner $runner,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('uuid', InputArgument::REQUIRED, 'Code task UUID');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $uuid = (string) $input->getArgument('uuid');
+
+        $tasks = $this->codeTaskRepo->findBy(['uuid' => $uuid]);
+        if ($tasks === []) {
+            $output->writeln('<error>Code task not found: '.$uuid.'</error>');
+
+            return Command::FAILURE;
+        }
+
+        $task = $tasks[0];
+        if (! $task instanceof CodeTask) {
+            $output->writeln('<error>Code task not found: '.$uuid.'</error>');
+
+            return Command::FAILURE;
+        }
+
+        $gitManager = new GitRepositoryManager;
+        $workspaceUuid = (string) $task->get('workspace_uuid');
+        $repoPath = $gitManager->buildWorkspaceRepoPath($workspaceUuid);
+
+        $output->writeln(sprintf('Running code task %s against %s...', $uuid, $repoPath));
+
+        $this->runner->run($task, $repoPath);
+
+        $output->writeln(sprintf('Task %s finished with status: %s', $uuid, (string) $task->get('status')));
+
+        return $task->get('status') === 'completed' ? Command::SUCCESS : Command::FAILURE;
+    }
+}

--- a/src/Domain/CodeTask/CodeTaskRunner.php
+++ b/src/Domain/CodeTask/CodeTaskRunner.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Claudriel\Domain\CodeTask;
 
-use Claudriel\Domain\Git\GitRepositoryManager;
 use Claudriel\Entity\CodeTask;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 
@@ -21,7 +20,6 @@ final class CodeTaskRunner
 
     public function __construct(
         private readonly EntityRepositoryInterface $codeTaskRepo,
-        private readonly GitRepositoryManager $gitManager, // @phpstan-ignore property.onlyWritten
         ?callable $processRunner = null,
     ) {
         $this->processRunner = $processRunner;
@@ -37,8 +35,8 @@ final class CodeTaskRunner
             $this->prepareWorkingBranch($repoPath, (string) $task->get('branch_name'));
             $result = $this->invokeClaudeCode($repoPath, (string) $task->get('prompt'));
 
-            $exitCode = (int) ($result['exit_code'] ?? 1);
-            $output = (string) ($result['output'] ?? '');
+            $exitCode = (int) $result['exit_code'];
+            $output = (string) $result['output'];
 
             $task->set('claude_output', mb_substr($output, 0, 50000));
 
@@ -102,6 +100,9 @@ final class CodeTaskRunner
         ));
     }
 
+    /**
+     * @return array{exit_code: int, output: string}
+     */
     private function invokeClaudeCode(string $repoPath, string $prompt): array
     {
         if ($this->processRunner !== null) {
@@ -197,8 +198,8 @@ final class CodeTaskRunner
 
     private function shellExec(string $command): void
     {
-        shell_exec($command.' 2>&1');
-        // Fire and forget for git operations - errors caught by caller
+        $output = shell_exec($command.' 2>&1');
+        // Fire and forget for git operations — errors caught by caller
     }
 
     private function shellExecSafe(string $command): string

--- a/src/Provider/CodeTaskServiceProvider.php
+++ b/src/Provider/CodeTaskServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Claudriel\Provider;
 
 use Claudriel\Domain\CodeTask\CodeTaskRunner;
-use Claudriel\Domain\Git\GitRepositoryManager;
 use Claudriel\Entity\CodeTask;
 use Claudriel\Support\StorageRepositoryAdapter;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -29,10 +28,7 @@ final class CodeTaskServiceProvider extends ServiceProvider
             $storage = new SqlEntityStorage($entityType, $database, $dispatcher);
             $repo = new StorageRepositoryAdapter($storage);
 
-            return new CodeTaskRunner(
-                $repo,
-                new GitRepositoryManager,
-            );
+            return new CodeTaskRunner($repo);
         });
 
         $this->entityType(new EntityType(

--- a/tests/Unit/Command/CodeTaskRunCommandTest.php
+++ b/tests/Unit/Command/CodeTaskRunCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Command;
+
+use Claudriel\Command\CodeTaskRunCommand;
+use Claudriel\Domain\CodeTask\CodeTaskRunner;
+use Claudriel\Entity\CodeTask;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+
+final class CodeTaskRunCommandTest extends TestCase
+{
+    private function makeRunner(?EntityRepositoryInterface $repo = null, ?callable $processRunner = null): CodeTaskRunner
+    {
+        $repo ??= $this->createMock(EntityRepositoryInterface::class);
+
+        return new CodeTaskRunner($repo, $processRunner);
+    }
+
+    public function test_requires_uuid_argument(): void
+    {
+        $repo = $this->createMock(EntityRepositoryInterface::class);
+        $runner = $this->makeRunner($repo);
+
+        $command = new CodeTaskRunCommand($repo, $runner);
+        $app = new Application;
+        $app->add($command);
+
+        $tester = new CommandTester($command);
+        $this->expectException(RuntimeException::class);
+        $tester->execute([]);
+    }
+
+    public function test_fails_when_task_not_found(): void
+    {
+        $repo = $this->createMock(EntityRepositoryInterface::class);
+        $repo->method('findBy')->willReturn([]);
+
+        $runner = $this->makeRunner($repo);
+
+        $command = new CodeTaskRunCommand($repo, $runner);
+        $app = new Application;
+        $app->add($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['uuid' => 'nonexistent']);
+
+        $this->assertSame(1, $tester->getStatusCode());
+        $this->assertStringContainsString('not found', $tester->getDisplay());
+    }
+
+    public function test_runs_task_successfully(): void
+    {
+        $task = new CodeTask([
+            'uuid' => 'task-1',
+            'workspace_uuid' => 'ws-1',
+            'repo_uuid' => 'repo-1',
+            'prompt' => 'Fix bug',
+            'branch_name' => 'claudriel/fix-bug',
+            'status' => 'queued',
+        ]);
+
+        $repo = $this->createMock(EntityRepositoryInterface::class);
+        $repo->method('findBy')->willReturn([$task]);
+
+        $runner = $this->makeRunner($repo, fn () => [
+            'exit_code' => 0,
+            'output' => 'Done.',
+        ]);
+
+        $command = new CodeTaskRunCommand($repo, $runner);
+        $app = new Application;
+        $app->add($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['uuid' => 'task-1']);
+
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+}

--- a/tests/Unit/Domain/CodeTask/CodeTaskRunnerTest.php
+++ b/tests/Unit/Domain/CodeTask/CodeTaskRunnerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Claudriel\Tests\Unit\Domain\CodeTask;
 
 use Claudriel\Domain\CodeTask\CodeTaskRunner;
-use Claudriel\Domain\Git\GitRepositoryManager;
 use Claudriel\Entity\CodeTask;
 use PHPUnit\Framework\TestCase;
 use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
@@ -25,9 +24,7 @@ final class CodeTaskRunnerTest extends TestCase
         $repo = $this->createMock(EntityRepositoryInterface::class);
         $repo->expects($this->atLeastOnce())->method('save');
 
-        $gitManager = new GitRepositoryManager(runner: fn () => ['exit_code' => 0, 'output' => '']);
-
-        $runner = new CodeTaskRunner($repo, $gitManager, fn () => [
+        $runner = new CodeTaskRunner($repo, fn () => [
             'exit_code' => 0,
             'output' => json_encode([
                 'result' => 'I fixed the login bug by updating the session handler.',
@@ -53,9 +50,7 @@ final class CodeTaskRunnerTest extends TestCase
         $repo = $this->createMock(EntityRepositoryInterface::class);
         $repo->expects($this->atLeastOnce())->method('save');
 
-        $gitManager = new GitRepositoryManager(runner: fn () => ['exit_code' => 0, 'output' => '']);
-
-        $runner = new CodeTaskRunner($repo, $gitManager, fn () => [
+        $runner = new CodeTaskRunner($repo, fn () => [
             'exit_code' => 1,
             'output' => 'Error: something went wrong',
         ]);
@@ -69,8 +64,7 @@ final class CodeTaskRunnerTest extends TestCase
     public function test_generate_branch_name(): void
     {
         $repo = $this->createMock(EntityRepositoryInterface::class);
-        $gitManager = new GitRepositoryManager(runner: fn () => ['exit_code' => 0, 'output' => '']);
-        $runner = new CodeTaskRunner($repo, $gitManager);
+        $runner = new CodeTaskRunner($repo);
 
         $result = $runner->generateBranchName('Fix the login bug in auth module!');
         $this->assertSame('claudriel/fix-the-login-bug-in-auth-module', $result);
@@ -79,8 +73,7 @@ final class CodeTaskRunnerTest extends TestCase
     public function test_generate_branch_name_truncates(): void
     {
         $repo = $this->createMock(EntityRepositoryInterface::class);
-        $gitManager = new GitRepositoryManager(runner: fn () => ['exit_code' => 0, 'output' => '']);
-        $runner = new CodeTaskRunner($repo, $gitManager);
+        $runner = new CodeTaskRunner($repo);
 
         $longPrompt = str_repeat('a very long prompt that goes on ', 5);
         $result = $runner->generateBranchName($longPrompt);


### PR DESCRIPTION
## Summary

- Add `CodeTask` entity with queued/running/completed/failed lifecycle and nullable fields for PR URL, summary, diff preview, error, and Claude output
- Add `CodeTaskRunner` service that orchestrates Claude Code CLI invocation with branch naming, diff capture, and PR creation
- Add `claudriel:code-task:run` CLI command that loads a task by UUID, resolves the repo path, and delegates to the runner

## Test plan

- [x] Unit tests for CodeTask entity defaults and explicit values (4 tests)
- [x] Unit tests for CodeTaskRunner: status transitions on success/failure, branch name generation and truncation (4 tests)
- [x] Unit tests for CodeTaskRunCommand: missing argument, task not found, successful run (3 tests)
- [x] Full test suite passes (812 tests)
- [x] PHPStan passes with no errors
- [x] Pint lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)