### PR TITLE
feat(#575): add InternalCodeTaskController with create and status endpoints

### DIFF
--- a/src/Controller/InternalCodeTaskController.php
+++ b/src/Controller/InternalCodeTaskController.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Controller;
+
+use Claudriel\Domain\Chat\InternalApiTokenGenerator;
+use Claudriel\Domain\CodeTask\CodeTaskRunner;
+use Claudriel\Domain\Git\GitRepositoryManager;
+use Claudriel\Entity\CodeTask;
+use Claudriel\Entity\Repo;
+use Claudriel\Entity\Workspace;
+use Claudriel\Entity\WorkspaceRepo;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Access\AccountInterface;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+use Waaseyaa\SSR\SsrResponse;
+
+final class InternalCodeTaskController
+{
+    public function __construct(
+        private readonly EntityRepositoryInterface $codeTaskRepo,
+        private readonly EntityRepositoryInterface $workspaceRepo,
+        private readonly EntityRepositoryInterface $repoRepo,
+        private readonly EntityRepositoryInterface $workspaceRepoRepo,
+        private readonly InternalApiTokenGenerator $apiTokenGenerator,
+        private readonly CodeTaskRunner $runner,
+        private readonly GitRepositoryManager $gitManager,
+    ) {}
+
+    public function create(array $params = [], array $query = [], ?AccountInterface $account = null, ?Request $httpRequest = null): SsrResponse
+    {
+        if ($this->authenticate($httpRequest) === null) {
+            return $this->jsonError('Unauthorized', 401);
+        }
+
+        $body = $this->getRequestBody($httpRequest);
+        if ($body === null) {
+            return $this->jsonError('Invalid request body', 400);
+        }
+
+        $repoFullName = (string) ($body['repo'] ?? '');
+        $prompt = (string) ($body['prompt'] ?? '');
+        if ($repoFullName === '' || $prompt === '') {
+            return $this->jsonError('repo and prompt are required', 400);
+        }
+
+        $tenantId = $this->resolveTenantId($httpRequest);
+
+        // Find or create workspace + repo
+        try {
+            $workspaceUuid = $this->resolveOrCreateWorkspace($repoFullName, $tenantId);
+        } catch (\RuntimeException) {
+            return $this->jsonError('Failed to set up workspace for repo', 500);
+        }
+
+        $repoUuid = $this->resolveRepoUuid($repoFullName, $tenantId);
+        if ($repoUuid === null) {
+            return $this->jsonError('Failed to resolve repo', 500);
+        }
+
+        $branchName = (string) ($body['branch_name'] ?? '');
+        if ($branchName === '') {
+            $branchName = $this->runner->generateBranchName($prompt);
+        }
+
+        $task = new CodeTask([
+            'workspace_uuid' => $workspaceUuid,
+            'repo_uuid' => $repoUuid,
+            'prompt' => $prompt,
+            'status' => 'queued',
+            'branch_name' => $branchName,
+            'tenant_id' => $tenantId,
+        ]);
+        $this->codeTaskRepo->save($task);
+
+        $taskUuid = (string) $task->get('uuid');
+
+        // Dispatch background command
+        $consolePath = dirname(__DIR__, 2).'/bin/console';
+        $cmd = sprintf(
+            'php %s claudriel:code-task:run %s > /dev/null 2>&1 &',
+            escapeshellarg($consolePath),
+            escapeshellarg($taskUuid),
+        );
+        exec($cmd);
+
+        return $this->jsonResponse([
+            'task_uuid' => $taskUuid,
+            'status' => 'queued',
+            'branch_name' => $branchName,
+        ]);
+    }
+
+    public function status(array $params = [], array $query = [], ?AccountInterface $account = null, ?Request $httpRequest = null): SsrResponse
+    {
+        if ($this->authenticate($httpRequest) === null) {
+            return $this->jsonError('Unauthorized', 401);
+        }
+
+        $uuid = (string) ($params['uuid'] ?? '');
+        if ($uuid === '') {
+            return $this->jsonError('Task UUID required', 400);
+        }
+
+        $tasks = $this->codeTaskRepo->findBy(['uuid' => $uuid]);
+        if ($tasks === []) {
+            return $this->jsonError('Code task not found', 404);
+        }
+
+        $task = $tasks[0];
+        if (! $task instanceof CodeTask) {
+            return $this->jsonError('Code task not found', 404);
+        }
+
+        return $this->jsonResponse([
+            'uuid' => $task->get('uuid'),
+            'status' => $task->get('status'),
+            'branch_name' => $task->get('branch_name'),
+            'pr_url' => $task->get('pr_url'),
+            'summary' => $task->get('summary'),
+            'diff_preview' => $task->get('diff_preview'),
+            'error' => $task->get('error'),
+            'started_at' => $task->get('started_at'),
+            'completed_at' => $task->get('completed_at'),
+        ]);
+    }
+
+    private function resolveOrCreateWorkspace(string $repoFullName, string $tenantId): string
+    {
+        // Check if we have a repo entity for this full name
+        $repos = $this->repoRepo->findBy(['full_name' => $repoFullName, 'tenant_id' => $tenantId]);
+        if ($repos !== []) {
+            $repo = $repos[0];
+            if ($repo instanceof Repo) {
+                // Find linked workspace
+                $links = $this->workspaceRepoRepo->findBy(['repo_uuid' => $repo->get('uuid')]);
+                foreach ($links as $link) {
+                    if ($link instanceof WorkspaceRepo) {
+                        return (string) $link->get('workspace_uuid');
+                    }
+                }
+            }
+        }
+
+        // Create workspace for this repo
+        $workspace = new Workspace([
+            'name' => $repoFullName,
+            'description' => 'Auto-created for code tasks on '.$repoFullName,
+            'tenant_id' => $tenantId,
+            'status' => 'active',
+        ]);
+        $this->workspaceRepo->save($workspace);
+        $wsUuid = (string) $workspace->get('uuid');
+
+        // Clone the repo
+        $repoUrl = 'https://github.com/'.$repoFullName.'.git';
+        $localPath = $this->gitManager->buildWorkspaceRepoPath($wsUuid);
+        $this->gitManager->clone($repoUrl, $localPath);
+
+        // Create repo entity
+        $parts = explode('/', $repoFullName, 2);
+        $repoEntity = new Repo([
+            'owner' => $parts[0],
+            'name' => $parts[1] ?? '',
+            'full_name' => $repoFullName,
+            'default_branch' => 'main',
+            'local_path' => $localPath,
+            'tenant_id' => $tenantId,
+        ]);
+        $this->repoRepo->save($repoEntity);
+
+        // Link workspace to repo
+        $link = new WorkspaceRepo([
+            'workspace_uuid' => $wsUuid,
+            'repo_uuid' => (string) $repoEntity->get('uuid'),
+            'is_active' => true,
+        ]);
+        $this->workspaceRepoRepo->save($link);
+
+        return $wsUuid;
+    }
+
+    private function resolveRepoUuid(string $repoFullName, string $tenantId): ?string
+    {
+        $repos = $this->repoRepo->findBy(['full_name' => $repoFullName, 'tenant_id' => $tenantId]);
+        if ($repos === []) {
+            return null;
+        }
+
+        $repo = $repos[0];
+
+        return $repo instanceof Repo ? (string) $repo->get('uuid') : null;
+    }
+
+    private function resolveTenantId(mixed $httpRequest): string
+    {
+        if ($httpRequest instanceof Request) {
+            $headerTenant = $httpRequest->headers->get('X-Tenant-Id', '');
+            if ($headerTenant !== '') {
+                return $headerTenant;
+            }
+        }
+
+        return 'default';
+    }
+
+    private function authenticate(mixed $httpRequest): ?string
+    {
+        $auth = '';
+        if ($httpRequest instanceof Request) {
+            $auth = $httpRequest->headers->get('Authorization', '');
+        }
+
+        if (! str_starts_with($auth, 'Bearer ')) {
+            return null;
+        }
+
+        return $this->apiTokenGenerator->validate(substr($auth, 7));
+    }
+
+    private function getRequestBody(mixed $httpRequest): ?array
+    {
+        if (! $httpRequest instanceof Request) {
+            return null;
+        }
+        $content = $httpRequest->getContent();
+        if ($content === '') {
+            return null;
+        }
+
+        $data = json_decode($content, true);
+
+        return is_array($data) ? $data : null;
+    }
+
+    private function jsonResponse(array $data): SsrResponse
+    {
+        return new SsrResponse(
+            content: json_encode($data, JSON_THROW_ON_ERROR),
+            statusCode: 200,
+            headers: ['Content-Type' => 'application/json'],
+        );
+    }
+
+    private function jsonError(string $message, int $statusCode): SsrResponse
+    {
+        return new SsrResponse(
+            content: json_encode(['error' => $message], JSON_THROW_ON_ERROR),
+            statusCode: $statusCode,
+            headers: ['Content-Type' => 'application/json'],
+        );
+    }
+}

--- a/tests/Unit/Controller/InternalCodeTaskControllerTest.php
+++ b/tests/Unit/Controller/InternalCodeTaskControllerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Controller;
+
+use Claudriel\Controller\InternalCodeTaskController;
+use Claudriel\Domain\Chat\InternalApiTokenGenerator;
+use Claudriel\Domain\CodeTask\CodeTaskRunner;
+use Claudriel\Domain\Git\GitRepositoryManager;
+use Claudriel\Entity\CodeTask;
+use Claudriel\Entity\Repo;
+use Claudriel\Entity\Workspace;
+use Claudriel\Entity\WorkspaceRepo;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\Driver\InMemoryStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository;
+
+final class InternalCodeTaskControllerTest extends TestCase
+{
+    private const SECRET = 'test-secret-that-is-at-least-32-bytes-long';
+
+    private InternalApiTokenGenerator $tokenGenerator;
+
+    private EntityRepository $codeTaskRepo;
+
+    private EntityRepository $workspaceRepo;
+
+    private EntityRepository $repoRepo;
+
+    private EntityRepository $workspaceRepoRepo;
+
+    protected function setUp(): void
+    {
+        $this->tokenGenerator = new InternalApiTokenGenerator(self::SECRET);
+
+        $this->codeTaskRepo = new EntityRepository(
+            new EntityType(
+                id: 'code_task',
+                label: 'Code Task',
+                class: CodeTask::class,
+                keys: ['id' => 'ctid', 'uuid' => 'uuid', 'label' => 'prompt'],
+            ),
+            new InMemoryStorageDriver,
+            new EventDispatcher,
+        );
+
+        $this->workspaceRepo = new EntityRepository(
+            new EntityType(
+                id: 'workspace',
+                label: 'Workspace',
+                class: Workspace::class,
+                keys: ['id' => 'wid', 'uuid' => 'uuid', 'label' => 'name'],
+            ),
+            new InMemoryStorageDriver,
+            new EventDispatcher,
+        );
+
+        $this->repoRepo = new EntityRepository(
+            new EntityType(
+                id: 'repo',
+                label: 'Repo',
+                class: Repo::class,
+                keys: ['id' => 'rid', 'uuid' => 'uuid', 'label' => 'name'],
+            ),
+            new InMemoryStorageDriver,
+            new EventDispatcher,
+        );
+
+        $this->workspaceRepoRepo = new EntityRepository(
+            new EntityType(
+                id: 'workspace_repo',
+                label: 'Workspace Repo',
+                class: WorkspaceRepo::class,
+                keys: ['id' => 'wrid', 'uuid' => 'uuid'],
+            ),
+            new InMemoryStorageDriver,
+            new EventDispatcher,
+        );
+    }
+
+    public function test_create_rejects_unauthenticated(): void
+    {
+        $controller = $this->makeController();
+        $request = Request::create('/api/internal/code-tasks/create', 'POST', content: '{}');
+
+        $response = $controller->create([], [], null, $request);
+        self::assertSame(401, $response->statusCode);
+    }
+
+    public function test_create_requires_repo_and_prompt(): void
+    {
+        $controller = $this->makeController();
+        $request = $this->authenticatedPostRequest(
+            '/api/internal/code-tasks/create',
+            'acct-1',
+            [],
+        );
+
+        $response = $controller->create([], [], null, $request);
+        self::assertSame(400, $response->statusCode);
+
+        $data = json_decode($response->content, true);
+        self::assertStringContainsString('repo and prompt are required', $data['error']);
+    }
+
+    public function test_status_rejects_unauthenticated(): void
+    {
+        $controller = $this->makeController();
+        $request = Request::create('/api/internal/code-tasks/task-1/status', 'GET');
+
+        $response = $controller->status(['uuid' => 'task-1'], [], null, $request);
+        self::assertSame(401, $response->statusCode);
+    }
+
+    public function test_status_returns_not_found_for_missing_task(): void
+    {
+        $controller = $this->makeController();
+        $token = $this->tokenGenerator->generate('acct-1');
+        $request = Request::create('/api/internal/code-tasks/nonexistent/status', 'GET');
+        $request->headers->set('Authorization', 'Bearer '.$token);
+
+        $response = $controller->status(['uuid' => 'nonexistent'], [], null, $request);
+        self::assertSame(404, $response->statusCode);
+    }
+
+    public function test_status_returns_task_data(): void
+    {
+        $task = new CodeTask([
+            'ctid' => 1,
+            'uuid' => 'task-1',
+            'workspace_uuid' => 'ws-1',
+            'repo_uuid' => 'repo-1',
+            'prompt' => 'Fix the bug',
+            'status' => 'completed',
+            'summary' => 'Fixed the bug',
+            'pr_url' => 'https://github.com/test/repo/pull/1',
+            'diff_preview' => '--- a/file.php',
+            'tenant_id' => 'default',
+        ]);
+        $this->codeTaskRepo->save($task);
+
+        $controller = $this->makeController();
+        $token = $this->tokenGenerator->generate('acct-1');
+        $request = Request::create('/api/internal/code-tasks/task-1/status', 'GET');
+        $request->headers->set('Authorization', 'Bearer '.$token);
+
+        $response = $controller->status(['uuid' => 'task-1'], [], null, $request);
+        self::assertSame(200, $response->statusCode);
+
+        $data = json_decode($response->content, true);
+        self::assertSame('completed', $data['status']);
+        self::assertSame('Fixed the bug', $data['summary']);
+        self::assertSame('https://github.com/test/repo/pull/1', $data['pr_url']);
+    }
+
+    private function makeController(): InternalCodeTaskController
+    {
+        $runner = new CodeTaskRunner(
+            $this->codeTaskRepo,
+            new GitRepositoryManager(runner: fn () => ['exit_code' => 0, 'output' => '']),
+            fn () => ['exit_code' => 0, 'output' => ''],
+        );
+
+        $gitManager = new GitRepositoryManager(
+            '/tmp/claudriel-test-workspaces',
+            fn () => ['exit_code' => 0, 'output' => ''],
+        );
+
+        return new InternalCodeTaskController(
+            $this->codeTaskRepo,
+            $this->workspaceRepo,
+            $this->repoRepo,
+            $this->workspaceRepoRepo,
+            $this->tokenGenerator,
+            $runner,
+            $gitManager,
+        );
+    }
+
+    private function authenticatedPostRequest(string $uri, string $accountId, array $body = []): Request
+    {
+        $token = $this->tokenGenerator->generate($accountId);
+        $content = $body !== [] ? json_encode($body, JSON_THROW_ON_ERROR) : '{}';
+        $request = Request::create($uri, 'POST', content: $content);
+        $request->headers->set('Authorization', 'Bearer '.$token);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `CodeTask` entity with lifecycle defaults (queued, running, completed, failed)
- Adds `CodeTaskRunner` service that orchestrates Claude Code CLI invocation, branch management, diff capture, and PR creation
- Adds `InternalCodeTaskController` with two HMAC-authenticated endpoints:
  - `POST /api/internal/code-tasks/create` -- accepts repo + prompt, sets up workspace/repo, creates task, dispatches background CLI
  - `GET /api/internal/code-tasks/{uuid}/status` -- returns task status, PR URL, summary, diff preview

## Test plan

- [x] Unit tests pass (5 tests, 9 assertions) covering auth rejection, input validation, and status retrieval
- [x] Full test suite passes (806 tests, 2454 assertions)
- [x] PHPStan passes with no errors
- [x] Pint formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)