### PR TITLE
fix(#587): add branch_name default to CodeTask constructor

### DIFF
--- a/src/Entity/CodeTask.php
+++ b/src/Entity/CodeTask.php
@@ -42,6 +42,9 @@ final class CodeTask extends ContentEntityBase
         if (! array_key_exists('completed_at', $values)) {
             $values['completed_at'] = null;
         }
+        if (! array_key_exists('branch_name', $values)) {
+            $values['branch_name'] = null;
+        }
 
         parent::__construct($values, $this->entityTypeId, $this->entityKeys);
     }

--- a/tests/Unit/Entity/CodeTaskTest.php
+++ b/tests/Unit/Entity/CodeTaskTest.php
@@ -39,6 +39,12 @@ final class CodeTaskTest extends TestCase
         $this->assertSame('claudriel/fix-login', $task->get('branch_name'));
     }
 
+    public function test_branch_name_defaults_to_null(): void
+    {
+        $task = new CodeTask(['workspace_uuid' => 'ws-1', 'repo_uuid' => 'repo-1', 'prompt' => 'Fix bug']);
+        $this->assertNull($task->get('branch_name'));
+    }
+
     public function test_entity_type_id(): void
     {
         $task = new CodeTask;


### PR DESCRIPTION
Closes #587 (partial)

## Summary
- Added `branch_name` default (`null`) to `CodeTask` constructor, matching the pattern of all other nullable fields
- Added test asserting the default

## Test plan
- [x] `vendor/bin/phpunit tests/Unit/Entity/CodeTaskTest.php` passes
- [x] Full test suite (686 tests) passes
- [x] PHPStan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)