### PR TITLE
feat(#594): add CodeTask and RepoClone PHP agent tools with tests

### DIFF
--- a/src/Domain/Chat/Tool/CodeTaskCreateTool.php
+++ b/src/Domain/Chat/Tool/CodeTaskCreateTool.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Chat\Tool;
+
+use Claudriel\Domain\Chat\AgentToolInterface;
+use Claudriel\Domain\Chat\InternalApiTokenGenerator;
+
+final class CodeTaskCreateTool implements AgentToolInterface
+{
+    public function __construct(
+        private readonly string $apiBaseUrl,
+        private readonly string $accountId,
+        private readonly string $tenantId,
+        private readonly InternalApiTokenGenerator $tokenGenerator,
+    ) {}
+
+    public function definition(): array
+    {
+        return [
+            'name' => 'code_task_create',
+            'description' => 'Create a code task that uses Claude Code to make changes to a GitHub repository. The task will clone the repo, create a branch, apply the requested changes, and open a pull request. Use code_task_status to check progress.',
+            'input_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'repo' => [
+                        'type' => 'string',
+                        'description' => 'GitHub repo in owner/name format (e.g. "jonesrussell/blog").',
+                    ],
+                    'prompt' => [
+                        'type' => 'string',
+                        'description' => 'Description of the code changes to make.',
+                    ],
+                    'branch_name' => [
+                        'type' => 'string',
+                        'description' => 'Optional branch name. Auto-generated from prompt if omitted.',
+                    ],
+                ],
+                'required' => ['repo', 'prompt'],
+            ],
+        ];
+    }
+
+    public function execute(array $args): array
+    {
+        $repo = trim((string) ($args['repo'] ?? ''));
+        $prompt = trim((string) ($args['prompt'] ?? ''));
+
+        if ($repo === '' || $prompt === '') {
+            return ['error' => 'repo and prompt are required'];
+        }
+
+        if (preg_match('#^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$#', $repo) !== 1) {
+            return ['error' => 'repo must be in owner/name format'];
+        }
+
+        $body = ['repo' => $repo, 'prompt' => $prompt];
+        $branchName = trim((string) ($args['branch_name'] ?? ''));
+        if ($branchName !== '') {
+            $body['branch_name'] = $branchName;
+        }
+
+        $token = $this->tokenGenerator->generate($this->accountId);
+        $url = rtrim($this->apiBaseUrl, '/').'/api/internal/code-tasks/create';
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => implode("\r\n", [
+                    'Content-Type: application/json',
+                    'Authorization: Bearer '.$token,
+                    'X-Tenant-Id: '.$this->tenantId,
+                ]),
+                'content' => json_encode($body, JSON_THROW_ON_ERROR),
+                'ignore_errors' => true,
+            ],
+        ]);
+
+        $response = file_get_contents($url, false, $context);
+        if ($response === false) {
+            return ['error' => 'Failed to reach code task API'];
+        }
+
+        $data = json_decode($response, true);
+        if (! is_array($data)) {
+            return ['error' => 'Invalid response from code task API'];
+        }
+
+        return $data;
+    }
+}

--- a/src/Domain/Chat/Tool/CodeTaskStatusTool.php
+++ b/src/Domain/Chat/Tool/CodeTaskStatusTool.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Chat\Tool;
+
+use Claudriel\Domain\Chat\AgentToolInterface;
+use Claudriel\Entity\CodeTask;
+use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
+
+final class CodeTaskStatusTool implements AgentToolInterface
+{
+    public function __construct(
+        private readonly EntityRepositoryInterface $codeTaskRepo,
+    ) {}
+
+    public function definition(): array
+    {
+        return [
+            'name' => 'code_task_status',
+            'description' => 'Check the status of a code task. Returns the current status, PR URL (if created), summary, and any errors.',
+            'input_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'task_uuid' => [
+                        'type' => 'string',
+                        'description' => 'UUID of the code task to check.',
+                    ],
+                ],
+                'required' => ['task_uuid'],
+            ],
+        ];
+    }
+
+    public function execute(array $args): array
+    {
+        $uuid = trim((string) ($args['task_uuid'] ?? ''));
+        if ($uuid === '') {
+            return ['error' => 'task_uuid is required'];
+        }
+
+        $tasks = $this->codeTaskRepo->findBy(['uuid' => $uuid]);
+        if ($tasks === []) {
+            return ['error' => 'Code task not found'];
+        }
+
+        $task = $tasks[0];
+        if (! $task instanceof CodeTask) {
+            return ['error' => 'Code task not found'];
+        }
+
+        return [
+            'uuid' => $task->get('uuid'),
+            'status' => $task->get('status'),
+            'branch_name' => $task->get('branch_name'),
+            'pr_url' => $task->get('pr_url'),
+            'summary' => $task->get('summary'),
+            'diff_preview' => $task->get('diff_preview'),
+            'error' => $task->get('error'),
+            'started_at' => $task->get('started_at'),
+            'completed_at' => $task->get('completed_at'),
+        ];
+    }
+}

--- a/src/Domain/Chat/Tool/RepoCloneTool.php
+++ b/src/Domain/Chat/Tool/RepoCloneTool.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Chat\Tool;
+
+use Claudriel\Domain\Chat\AgentToolInterface;
+use Claudriel\Domain\Chat\InternalApiTokenGenerator;
+
+final class RepoCloneTool implements AgentToolInterface
+{
+    public function __construct(
+        private readonly string $apiBaseUrl,
+        private readonly string $accountId,
+        private readonly string $tenantId,
+        private readonly InternalApiTokenGenerator $tokenGenerator,
+    ) {}
+
+    public function definition(): array
+    {
+        return [
+            'name' => 'repo_clone',
+            'description' => 'Clone a GitHub repository into a workspace. The repo will be available for code tasks after cloning.',
+            'input_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'workspace_uuid' => [
+                        'type' => 'string',
+                        'description' => 'UUID of the workspace to clone into.',
+                    ],
+                    'repo' => [
+                        'type' => 'string',
+                        'description' => 'GitHub repo in owner/name format (e.g. "jonesrussell/blog").',
+                    ],
+                    'branch' => [
+                        'type' => 'string',
+                        'description' => 'Optional branch to check out after cloning.',
+                    ],
+                ],
+                'required' => ['workspace_uuid', 'repo'],
+            ],
+        ];
+    }
+
+    public function execute(array $args): array
+    {
+        $workspaceUuid = trim((string) ($args['workspace_uuid'] ?? ''));
+        $repo = trim((string) ($args['repo'] ?? ''));
+
+        if ($workspaceUuid === '' || $repo === '') {
+            return ['error' => 'workspace_uuid and repo are required'];
+        }
+
+        if (preg_match('#^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$#', $repo) !== 1) {
+            return ['error' => 'repo must be in owner/name format'];
+        }
+
+        $body = ['repo' => $repo];
+        $branch = trim((string) ($args['branch'] ?? ''));
+        if ($branch !== '') {
+            $body['branch'] = $branch;
+        }
+
+        $token = $this->tokenGenerator->generate($this->accountId);
+        $url = rtrim($this->apiBaseUrl, '/').'/api/internal/workspaces/'.urlencode($workspaceUuid).'/clone-repo';
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => implode("\r\n", [
+                    'Content-Type: application/json',
+                    'Authorization: Bearer '.$token,
+                    'X-Tenant-Id: '.$this->tenantId,
+                ]),
+                'content' => json_encode($body, JSON_THROW_ON_ERROR),
+                'ignore_errors' => true,
+            ],
+        ]);
+
+        $response = file_get_contents($url, false, $context);
+        if ($response === false) {
+            return ['error' => 'Failed to reach repo clone API'];
+        }
+
+        $data = json_decode($response, true);
+        if (! is_array($data)) {
+            return ['error' => 'Invalid response from repo clone API'];
+        }
+
+        return $data;
+    }
+}

--- a/tests/Unit/Domain/Chat/Tool/CodeTaskCreateToolTest.php
+++ b/tests/Unit/Domain/Chat/Tool/CodeTaskCreateToolTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Domain\Chat\Tool;
+
+use Claudriel\Domain\Chat\InternalApiTokenGenerator;
+use Claudriel\Domain\Chat\Tool\CodeTaskCreateTool;
+use PHPUnit\Framework\TestCase;
+
+final class CodeTaskCreateToolTest extends TestCase
+{
+    private const SECRET = 'test-secret-that-is-at-least-32-bytes-long';
+
+    public function test_definition_has_required_fields(): void
+    {
+        $tool = $this->makeTool();
+        $def = $tool->definition();
+
+        self::assertSame('code_task_create', $def['name']);
+        self::assertArrayHasKey('description', $def);
+        self::assertSame(['repo', 'prompt'], $def['input_schema']['required']);
+    }
+
+    public function test_execute_rejects_empty_repo(): void
+    {
+        $tool = $this->makeTool();
+        $result = $tool->execute(['repo' => '', 'prompt' => 'Fix the bug']);
+
+        self::assertArrayHasKey('error', $result);
+        self::assertStringContainsString('required', $result['error']);
+    }
+
+    public function test_execute_rejects_empty_prompt(): void
+    {
+        $tool = $this->makeTool();
+        $result = $tool->execute(['repo' => 'owner/repo', 'prompt' => '']);
+
+        self::assertArrayHasKey('error', $result);
+        self::assertStringContainsString('required', $result['error']);
+    }
+
+    public function test_execute_rejects_invalid_repo_format(): void
+    {
+        $tool = $this->makeTool();
+        $result = $tool->execute(['repo' => 'not-a-valid-repo', 'prompt' => 'Fix it']);
+
+        self::assertArrayHasKey('error', $result);
+        self::assertStringContainsString('owner/name', $result['error']);
+    }
+
+    private function makeTool(): CodeTaskCreateTool
+    {
+        return new CodeTaskCreateTool(
+            'http://localhost:9999',
+            'acct-1',
+            'tenant-1',
+            new InternalApiTokenGenerator(self::SECRET),
+        );
+    }
+}

--- a/tests/Unit/Domain/Chat/Tool/CodeTaskStatusToolTest.php
+++ b/tests/Unit/Domain/Chat/Tool/CodeTaskStatusToolTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Domain\Chat\Tool;
+
+use Claudriel\Domain\Chat\Tool\CodeTaskStatusTool;
+use Claudriel\Entity\CodeTask;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\EntityStorage\Driver\InMemoryStorageDriver;
+use Waaseyaa\EntityStorage\EntityRepository;
+
+final class CodeTaskStatusToolTest extends TestCase
+{
+    public function test_definition_has_required_fields(): void
+    {
+        $tool = $this->makeTool();
+        $def = $tool->definition();
+
+        self::assertSame('code_task_status', $def['name']);
+        self::assertArrayHasKey('description', $def);
+        self::assertSame(['task_uuid'], $def['input_schema']['required']);
+    }
+
+    public function test_execute_rejects_empty_uuid(): void
+    {
+        $tool = $this->makeTool();
+        $result = $tool->execute(['task_uuid' => '']);
+
+        self::assertArrayHasKey('error', $result);
+        self::assertStringContainsString('required', $result['error']);
+    }
+
+    public function test_execute_returns_not_found_for_missing_task(): void
+    {
+        $tool = $this->makeTool();
+        $result = $tool->execute(['task_uuid' => 'nonexistent']);
+
+        self::assertArrayHasKey('error', $result);
+        self::assertStringContainsString('not found', $result['error']);
+    }
+
+    public function test_execute_returns_task_data(): void
+    {
+        $repo = $this->makeRepo();
+        $task = new CodeTask([
+            'ctid' => 1,
+            'uuid' => 'task-1',
+            'workspace_uuid' => 'ws-1',
+            'repo_uuid' => 'repo-1',
+            'prompt' => 'Fix the bug',
+            'status' => 'completed',
+            'summary' => 'Fixed it',
+            'pr_url' => 'https://github.com/test/repo/pull/1',
+            'tenant_id' => 'default',
+        ]);
+        $repo->save($task);
+
+        $tool = new CodeTaskStatusTool($repo);
+        $result = $tool->execute(['task_uuid' => 'task-1']);
+
+        self::assertSame('task-1', $result['uuid']);
+        self::assertSame('completed', $result['status']);
+        self::assertSame('Fixed it', $result['summary']);
+        self::assertSame('https://github.com/test/repo/pull/1', $result['pr_url']);
+    }
+
+    private function makeTool(): CodeTaskStatusTool
+    {
+        return new CodeTaskStatusTool($this->makeRepo());
+    }
+
+    private function makeRepo(): EntityRepository
+    {
+        return new EntityRepository(
+            new EntityType(
+                id: 'code_task',
+                label: 'Code Task',
+                class: CodeTask::class,
+                keys: ['id' => 'ctid', 'uuid' => 'uuid', 'label' => 'prompt'],
+            ),
+            new InMemoryStorageDriver,
+            new EventDispatcher,
+        );
+    }
+}

--- a/tests/Unit/Domain/Chat/Tool/RepoCloneToolTest.php
+++ b/tests/Unit/Domain/Chat/Tool/RepoCloneToolTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Domain\Chat\Tool;
+
+use Claudriel\Domain\Chat\InternalApiTokenGenerator;
+use Claudriel\Domain\Chat\Tool\RepoCloneTool;
+use PHPUnit\Framework\TestCase;
+
+final class RepoCloneToolTest extends TestCase
+{
+    private const SECRET = 'test-secret-that-is-at-least-32-bytes-long';
+
+    public function test_definition_has_required_fields(): void
+    {
+        $tool = $this->makeTool();
+        $def = $tool->definition();
+
+        self::assertSame('repo_clone', $def['name']);
+        self::assertArrayHasKey('description', $def);
+        self::assertSame(['workspace_uuid', 'repo'], $def['input_schema']['required']);
+    }
+
+    public function test_execute_rejects_empty_workspace_uuid(): void
+    {
+        $tool = $this->makeTool();
+        $result = $tool->execute(['workspace_uuid' => '', 'repo' => 'owner/repo']);
+
+        self::assertArrayHasKey('error', $result);
+        self::assertStringContainsString('required', $result['error']);
+    }
+
+    public function test_execute_rejects_empty_repo(): void
+    {
+        $tool = $this->makeTool();
+        $result = $tool->execute(['workspace_uuid' => 'ws-1', 'repo' => '']);
+
+        self::assertArrayHasKey('error', $result);
+        self::assertStringContainsString('required', $result['error']);
+    }
+
+    public function test_execute_rejects_invalid_repo_format(): void
+    {
+        $tool = $this->makeTool();
+        $result = $tool->execute(['workspace_uuid' => 'ws-1', 'repo' => 'invalid']);
+
+        self::assertArrayHasKey('error', $result);
+        self::assertStringContainsString('owner/name', $result['error']);
+    }
+
+    private function makeTool(): RepoCloneTool
+    {
+        return new RepoCloneTool(
+            'http://localhost:9999',
+            'acct-1',
+            'tenant-1',
+            new InternalApiTokenGenerator(self::SECRET),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add 3 agent tool source files: `CodeTaskCreateTool`, `CodeTaskStatusTool`, `RepoCloneTool`
- Add 12 unit tests across 3 test classes covering definition schemas, input validation (empty fields, invalid repo format), and entity lookup (CodeTaskStatusTool)
- Uses `InMemoryStorageDriver` + `EntityRepository` for CodeTaskStatusTool tests

## Test plan
- [x] `vendor/bin/phpunit tests/Unit/Domain/Chat/Tool/` — 12 tests, 19 assertions pass
- [x] `vendor/bin/phpunit` — full suite (697 tests) passes
- [x] `vendor/bin/phpstan analyse` — no errors

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)