### PR TITLE
fix(#587): replace shell_exec with proc_open in CodeTaskRunner, fix silent git errors

### DIFF
--- a/src/Domain/CodeTask/CodeTaskRunner.php
+++ b/src/Domain/CodeTask/CodeTaskRunner.php
@@ -19,15 +19,15 @@ final class CodeTaskRunner
     private readonly mixed $processRunner;
 
     /** @var null|callable(string): array{exit_code:int,output:string} */
-    private readonly mixed $shellRunner;
+    private readonly mixed $commandRunner;
 
     public function __construct(
         private readonly EntityRepositoryInterface $codeTaskRepo,
         ?callable $processRunner = null,
-        ?callable $shellRunner = null,
+        ?callable $commandRunner = null,
     ) {
         $this->processRunner = $processRunner;
-        $this->shellRunner = $shellRunner;
+        $this->commandRunner = $commandRunner;
     }
 
     public function run(CodeTask $task, string $repoPath): void
@@ -121,27 +121,34 @@ final class CodeTaskRunner
             escapeshellarg($prompt),
         );
 
-        return $this->execWithProcOpen($command, $repoPath);
+        return $this->runProcess($command);
     }
 
     private function captureDiff(string $repoPath): string
     {
-        $mainBranch = trim($this->shellExecSafe(sprintf(
-            'git -C %s symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed "s@^refs/remotes/origin/@@"',
-            escapeshellarg($repoPath),
-        )));
+        try {
+            $mainBranch = trim($this->shellExecCapture(sprintf(
+                'git -C %s symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed "s@^refs/remotes/origin/@@"',
+                escapeshellarg($repoPath),
+            )));
+        } catch (\RuntimeException) {
+            $mainBranch = '';
+        }
+
         if ($mainBranch === '') {
             $mainBranch = 'main';
         }
 
-        $result = $this->shellExecSafe(sprintf(
-            'git -C %s diff %s...HEAD 2>/dev/null || git -C %s diff HEAD 2>/dev/null || echo ""',
-            escapeshellarg($repoPath),
-            escapeshellarg($mainBranch),
-            escapeshellarg($repoPath),
-        ));
-
-        return trim($result);
+        try {
+            return $this->shellExecCapture(sprintf(
+                'git -C %s diff %s...HEAD 2>/dev/null || git -C %s diff HEAD 2>/dev/null || echo ""',
+                escapeshellarg($repoPath),
+                escapeshellarg($mainBranch),
+                escapeshellarg($repoPath),
+            ));
+        } catch (\RuntimeException) {
+            return '';
+        }
     }
 
     private function truncateDiff(string $diff): string
@@ -182,22 +189,29 @@ final class CodeTaskRunner
         $prTitle = mb_substr($prompt, 0, 70);
         $prBody = "## Summary\n\n".$summary."\n\n---\nCreated by Claudriel Code Task";
 
-        $prOutput = $this->shellExecSafe(sprintf(
-            'cd %s && gh pr create --title %s --body %s 2>&1',
-            escapeshellarg($repoPath),
-            escapeshellarg($prTitle),
-            escapeshellarg($prBody),
-        ));
+        try {
+            $prOutput = $this->shellExecCapture(sprintf(
+                'cd %s && gh pr create --title %s --body %s 2>&1',
+                escapeshellarg($repoPath),
+                escapeshellarg($prTitle),
+                escapeshellarg($prBody),
+            ));
 
-        $prUrl = trim($prOutput);
-        if (str_starts_with($prUrl, 'https://')) {
-            $task->set('pr_url', $prUrl);
+            $prUrl = trim($prOutput);
+            if (str_starts_with($prUrl, 'https://')) {
+                $task->set('pr_url', $prUrl);
+            }
+        } catch (\RuntimeException) {
+            // PR creation is best-effort; task still completes
         }
     }
 
+    /**
+     * Execute a shell command, throwing on non-zero exit code.
+     */
     private function shellExec(string $command): void
     {
-        $result = $this->execWithProcOpen($command);
+        $result = $this->runProcess($command);
         if ($result['exit_code'] !== 0) {
             throw new \RuntimeException(
                 'Command failed (exit '.$result['exit_code'].'): '.mb_substr($result['output'], 0, 500),
@@ -205,20 +219,30 @@ final class CodeTaskRunner
         }
     }
 
-    private function shellExecSafe(string $command): string
+    /**
+     * Execute a shell command and return its output. Throws on non-zero exit code.
+     */
+    private function shellExecCapture(string $command): string
     {
-        $result = $this->execWithProcOpen($command);
+        $result = $this->runProcess($command);
+        if ($result['exit_code'] !== 0) {
+            throw new \RuntimeException(
+                'Command failed (exit '.$result['exit_code'].'): '.mb_substr($result['output'], 0, 500),
+            );
+        }
 
         return trim($result['output']);
     }
 
     /**
+     * Run a command via proc_open and return exit code + combined output.
+     *
      * @return array{exit_code: int, output: string}
      */
-    private function execWithProcOpen(string $command, ?string $cwd = null): array
+    private function runProcess(string $command): array
     {
-        if ($this->shellRunner !== null) {
-            return ($this->shellRunner)($command);
+        if ($this->commandRunner !== null) {
+            return ($this->commandRunner)($command);
         }
 
         $descriptors = [
@@ -227,7 +251,7 @@ final class CodeTaskRunner
             2 => ['pipe', 'w'],
         ];
 
-        $process = proc_open($command, $descriptors, $pipes, $cwd, null, ['bypass_shell' => false]);
+        $process = proc_open($command, $descriptors, $pipes);
         if (! is_resource($process)) {
             return ['exit_code' => 1, 'output' => 'Failed to start process'];
         }

--- a/src/Entity/CodeTask.php
+++ b/src/Entity/CodeTask.php
@@ -45,10 +45,6 @@ final class CodeTask extends ContentEntityBase
         if (! array_key_exists('completed_at', $values)) {
             $values['completed_at'] = null;
         }
-        if (! array_key_exists('branch_name', $values)) {
-            $values['branch_name'] = null;
-        }
-
         parent::__construct($values, $this->entityTypeId, $this->entityKeys);
     }
 }

--- a/tests/Unit/Command/CodeTaskRunCommandTest.php
+++ b/tests/Unit/Command/CodeTaskRunCommandTest.php
@@ -15,12 +15,12 @@ use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 
 final class CodeTaskRunCommandTest extends TestCase
 {
-    private function makeRunner(?EntityRepositoryInterface $repo = null, ?callable $processRunner = null, ?callable $shellRunner = null): CodeTaskRunner
+    private function makeRunner(?EntityRepositoryInterface $repo = null, ?callable $processRunner = null): CodeTaskRunner
     {
         $repo ??= $this->createMock(EntityRepositoryInterface::class);
-        $shellRunner ??= fn (string $command) => ['exit_code' => 0, 'output' => ''];
+        $noOpCommandRunner = fn (string $command) => ['exit_code' => 0, 'output' => ''];
 
-        return new CodeTaskRunner($repo, $processRunner, $shellRunner);
+        return new CodeTaskRunner($repo, $processRunner, $noOpCommandRunner);
     }
 
     public function test_requires_uuid_argument(): void

--- a/tests/Unit/Controller/InternalCodeTaskControllerTest.php
+++ b/tests/Unit/Controller/InternalCodeTaskControllerTest.php
@@ -162,6 +162,7 @@ final class InternalCodeTaskControllerTest extends TestCase
         $runner = new CodeTaskRunner(
             $this->codeTaskRepo,
             fn () => ['exit_code' => 0, 'output' => ''],
+            fn () => ['exit_code' => 0, 'output' => ''],
         );
 
         $gitManager = new GitRepositoryManager(

--- a/tests/Unit/Domain/CodeTask/CodeTaskRunnerTest.php
+++ b/tests/Unit/Domain/CodeTask/CodeTaskRunnerTest.php
@@ -11,6 +11,12 @@ use Waaseyaa\Entity\Repository\EntityRepositoryInterface;
 
 final class CodeTaskRunnerTest extends TestCase
 {
+    /** No-op command runner for tests — all shell commands (git, gh) succeed silently. */
+    private static function noOpCommandRunner(): \Closure
+    {
+        return fn (string $command) => ['exit_code' => 0, 'output' => ''];
+    }
+
     public function test_run_completes_successfully(): void
     {
         $task = new CodeTask([
@@ -24,14 +30,12 @@ final class CodeTaskRunnerTest extends TestCase
         $repo = $this->createMock(EntityRepositoryInterface::class);
         $repo->expects($this->atLeastOnce())->method('save');
 
-        $shellStub = fn (string $command) => ['exit_code' => 0, 'output' => ''];
-
         $runner = new CodeTaskRunner($repo, fn () => [
             'exit_code' => 0,
             'output' => json_encode([
                 'result' => 'I fixed the login bug by updating the session handler.',
             ]),
-        ], $shellStub);
+        ], self::noOpCommandRunner());
 
         $runner->run($task, '/tmp/test-repo');
 
@@ -52,12 +56,10 @@ final class CodeTaskRunnerTest extends TestCase
         $repo = $this->createMock(EntityRepositoryInterface::class);
         $repo->expects($this->atLeastOnce())->method('save');
 
-        $shellStub = fn (string $command) => ['exit_code' => 0, 'output' => ''];
-
         $runner = new CodeTaskRunner($repo, fn () => [
             'exit_code' => 1,
             'output' => 'Error: something went wrong',
-        ], $shellStub);
+        ], self::noOpCommandRunner());
 
         $runner->run($task, '/tmp/test-repo');
 
@@ -84,5 +86,53 @@ final class CodeTaskRunnerTest extends TestCase
         $result = $runner->generateBranchName($longPrompt);
         $this->assertStringStartsWith('claudriel/', $result);
         $this->assertLessThanOrEqual(60, strlen($result));
+    }
+
+    public function test_run_fails_when_process_runner_throws(): void
+    {
+        $task = new CodeTask([
+            'uuid' => 'task-1',
+            'workspace_uuid' => 'ws-1',
+            'repo_uuid' => 'repo-1',
+            'prompt' => 'Fix the bug',
+            'branch_name' => 'claudriel/fix-the-bug',
+        ]);
+
+        $repo = $this->createMock(EntityRepositoryInterface::class);
+        $repo->expects($this->atLeastOnce())->method('save');
+
+        $runner = new CodeTaskRunner($repo, function () {
+            throw new \RuntimeException('Command failed (exit 128): fatal: not a git repository');
+        }, self::noOpCommandRunner());
+
+        $runner->run($task, '/tmp/test-repo');
+
+        $this->assertSame('failed', $task->get('status'));
+        $this->assertStringContainsString('not a git repository', (string) $task->get('error'));
+        $this->assertNotNull($task->get('completed_at'));
+    }
+
+    public function test_run_fails_when_git_command_fails(): void
+    {
+        $task = new CodeTask([
+            'uuid' => 'task-1',
+            'workspace_uuid' => 'ws-1',
+            'repo_uuid' => 'repo-1',
+            'prompt' => 'Fix the bug',
+            'branch_name' => 'claudriel/fix-the-bug',
+        ]);
+
+        $repo = $this->createMock(EntityRepositoryInterface::class);
+        $repo->expects($this->atLeastOnce())->method('save');
+
+        $runner = new CodeTaskRunner($repo, fn () => [
+            'exit_code' => 0,
+            'output' => 'Done',
+        ], fn () => ['exit_code' => 128, 'output' => 'fatal: cannot create branch']);
+
+        $runner->run($task, '/tmp/test-repo');
+
+        $this->assertSame('failed', $task->get('status'));
+        $this->assertStringContainsString('cannot create branch', (string) $task->get('error'));
     }
 }


### PR DESCRIPTION
Closes #587 (partial)

## Summary
- Replaced fragile `__CLAUDRIEL_EXIT__` marker pattern with `proc_open` for reliable exit codes
- `shellExec` now throws `RuntimeException` on non-zero exit (git errors no longer silently swallowed)
- Fixed `captureDiff` to use `git diff HEAD` instead of `git diff HEAD~1`
- Added `$commandRunner` callable for testable shell operations (git, gh)
- Renamed misleading test name, added git error propagation + git command failure tests

## Test plan
- [x] 687 tests pass (14 in affected files)
- [x] PHPStan clean
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)