### PR TITLE
feat(#620): reject password-less accounts on email/password login

### DIFF
--- a/src/Controller/PublicSessionController.php
+++ b/src/Controller/PublicSessionController.php
@@ -57,7 +57,29 @@ final class PublicSessionController
         }
 
         $resolvedAccount = $this->findVerifiedAccountByEmail($email);
-        if (! $resolvedAccount instanceof Account || ! password_verify($password, (string) $resolvedAccount->get('password_hash'))) {
+
+        if (! $resolvedAccount instanceof Account) {
+            return $this->render('public/login.twig', [
+                'csrf_token' => CsrfMiddleware::token(),
+                'email' => $email,
+                'redirect' => $redirect,
+                'error' => 'Invalid credentials.',
+            ], 401);
+        }
+
+        $passwordHash = (string) $resolvedAccount->get('password_hash');
+
+        if ($passwordHash === '') {
+            return $this->render('public/login.twig', [
+                'csrf_token' => CsrfMiddleware::token(),
+                'email' => $email,
+                'redirect' => $redirect,
+                'error' => 'This account uses Google sign-in. Use the "Sign in with Google" button below.',
+                'show_google_signin' => true,
+            ], 401);
+        }
+
+        if (! password_verify($password, $passwordHash)) {
             return $this->render('public/login.twig', [
                 'csrf_token' => CsrfMiddleware::token(),
                 'email' => $email,

--- a/tests/Unit/Controller/PublicSessionControllerTest.php
+++ b/tests/Unit/Controller/PublicSessionControllerTest.php
@@ -139,6 +139,34 @@ final class PublicSessionControllerTest extends TestCase
         self::assertStringContainsString('workspace-abc', $response->content);
     }
 
+    public function test_login_rejects_passwordless_account_with_google_signin_message(): void
+    {
+        $entityTypeManager = $this->buildEntityTypeManager();
+        $account = new Account([
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+            'password_hash' => null,
+            'status' => 'active',
+            'email_verified_at' => '2026-03-27T00:00:00+00:00',
+            'roles' => [],
+            'permissions' => [],
+        ]);
+        $entityTypeManager->getStorage('account')->save($account);
+
+        $controller = $this->controller($entityTypeManager);
+
+        $response = $controller->login(
+            httpRequest: Request::create('/login', 'POST', [
+                'email' => 'ada@example.com',
+                'password' => 'anything',
+            ]),
+        );
+
+        self::assertInstanceOf(SsrResponse::class, $response);
+        self::assertSame(401, $response->statusCode);
+        self::assertStringContainsString('Google sign-in', $response->content);
+    }
+
     private function controller(?EntityTypeManager $entityTypeManager = null): PublicSessionController
     {
         return new PublicSessionController(


### PR DESCRIPTION
## Summary
- Split the combined account-lookup + password-verify condition in `PublicSessionController::login()` into three sequential checks: account exists, password hash present, password valid
- Password-less accounts (Google sign-in users) now get a 401 with message: "This account uses Google sign-in. Use the 'Sign in with Google' button below." plus `show_google_signin => true` in template context
- Added test `test_login_rejects_passwordless_account_with_google_signin_message` to existing test file

## Test plan
- [x] New unit test passes: creates account with `password_hash=null`, attempts login, asserts 401 + Google sign-in message
- [x] All 832 existing tests pass
- [x] PHPStan reports no errors

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)