### PR TITLE
feat(#620): Google Sign-In backend auth flow

### DIFF
--- a/src/Controller/GoogleOAuthController.php
+++ b/src/Controller/GoogleOAuthController.php
@@ -6,12 +6,14 @@ namespace Claudriel\Controller;
 
 use Claudriel\Access\AuthenticatedAccount;
 use Claudriel\Entity\Integration;
+use Claudriel\Service\PublicAccountSignupService;
 use Claudriel\Support\AuthenticatedAccountSessionResolver;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
 use Waaseyaa\Access\AccountInterface;
 use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\User\Middleware\CsrfMiddleware;
 
 final class GoogleOAuthController
 {
@@ -36,11 +38,19 @@ final class GoogleOAuthController
         'https://www.googleapis.com/auth/drive.file',
     ];
 
+    private const SIGNIN_SCOPES = [
+        'openid',
+        'https://www.googleapis.com/auth/userinfo.email',
+        'https://www.googleapis.com/auth/userinfo.profile',
+    ];
+
     private readonly string $clientId;
 
     private readonly string $clientSecret;
 
     private readonly string $redirectUri;
+
+    private readonly string $signinRedirectUri;
 
     /** @phpstan-ignore constructor.unusedParameter */
     public function __construct(
@@ -50,6 +60,7 @@ final class GoogleOAuthController
         $this->clientId = $_ENV['GOOGLE_CLIENT_ID'] ?? getenv('GOOGLE_CLIENT_ID') ?: '';
         $this->clientSecret = $_ENV['GOOGLE_CLIENT_SECRET'] ?? getenv('GOOGLE_CLIENT_SECRET') ?: '';
         $this->redirectUri = $_ENV['GOOGLE_REDIRECT_URI'] ?? getenv('GOOGLE_REDIRECT_URI') ?: '';
+        $this->signinRedirectUri = $_ENV['GOOGLE_SIGNIN_REDIRECT_URI'] ?? getenv('GOOGLE_SIGNIN_REDIRECT_URI') ?: '';
     }
 
     public function redirect(
@@ -125,13 +136,97 @@ final class GoogleOAuthController
         return new RedirectResponse('/app', 302);
     }
 
-    private function exchangeCodeForTokens(string $code): ?array
+    public function signin(
+        array $params = [],
+        array $query = [],
+        ?AccountInterface $account = null,
+        ?Request $httpRequest = null,
+    ): RedirectResponse {
+        $state = bin2hex(random_bytes(32));
+        $_SESSION['google_oauth_state'] = $state;
+        $_SESSION['google_oauth_flow'] = 'signin';
+
+        $authUrl = self::AUTH_ENDPOINT.'?'.http_build_query([
+            'client_id' => $this->clientId,
+            'redirect_uri' => $this->signinRedirectUri,
+            'response_type' => 'code',
+            'scope' => implode(' ', self::SIGNIN_SCOPES),
+            'access_type' => 'offline',
+            'prompt' => 'consent',
+            'state' => $state,
+        ]);
+
+        return new RedirectResponse($authUrl, 302);
+    }
+
+    public function signinCallback(
+        array $params = [],
+        array $query = [],
+        ?AccountInterface $account = null,
+        ?Request $httpRequest = null,
+    ): RedirectResponse {
+        if (isset($query['error'])) {
+            $_SESSION['flash_error'] = 'Google sign-in denied: '.$query['error'];
+
+            return new RedirectResponse('/login', 302);
+        }
+
+        $expectedState = $_SESSION['google_oauth_state'] ?? null;
+        $expectedFlow = $_SESSION['google_oauth_flow'] ?? null;
+        unset($_SESSION['google_oauth_state'], $_SESSION['google_oauth_flow']);
+
+        if ($expectedState === null || $expectedFlow !== 'signin' || ! hash_equals($expectedState, $query['state'] ?? '')) {
+            $_SESSION['flash_error'] = 'Invalid OAuth state. Please try again.';
+
+            return new RedirectResponse('/login', 302);
+        }
+
+        $tokenData = $this->exchangeCodeForTokens($query['code'] ?? '', $this->signinRedirectUri);
+
+        if ($tokenData === null) {
+            $_SESSION['flash_error'] = 'Failed to exchange authorization code.';
+
+            return new RedirectResponse('/login', 302);
+        }
+
+        $userInfo = $this->fetchUserInfo($tokenData['access_token']);
+        $email = $userInfo['email'] ?? null;
+        $name = $userInfo['name'] ?? '';
+        $emailVerified = $userInfo['verified_email'] ?? false;
+
+        if ($email === null || ! $emailVerified) {
+            $_SESSION['flash_error'] = 'Google account email is not verified.';
+
+            return new RedirectResponse('/login', 302);
+        }
+
+        $signupService = new PublicAccountSignupService($this->entityTypeManager);
+        $accountEntity = $signupService->createFromGoogle($email, $name);
+
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        $_SESSION['claudriel_account_uuid'] = $accountEntity->get('uuid');
+        session_regenerate_id(true);
+        CsrfMiddleware::regenerate();
+
+        $this->upsertIntegration(
+            new AuthenticatedAccount($accountEntity),
+            $tokenData,
+            $email,
+        );
+
+        return new RedirectResponse('/app', 302);
+    }
+
+    private function exchangeCodeForTokens(string $code, ?string $overrideRedirectUri = null): ?array
     {
         $payload = http_build_query([
             'code' => $code,
             'client_id' => $this->clientId,
             'client_secret' => $this->clientSecret,
-            'redirect_uri' => $this->redirectUri,
+            'redirect_uri' => $overrideRedirectUri ?? $this->redirectUri,
             'grant_type' => 'authorization_code',
         ]);
 

--- a/src/Provider/AccountServiceProvider.php
+++ b/src/Provider/AccountServiceProvider.php
@@ -274,6 +274,24 @@ final class AccountServiceProvider extends ServiceProvider
         $googleCallbackRoute->setOption('_csrf', false);
         $router->addRoute('claudriel.auth.google.callback', $googleCallbackRoute);
 
+        // Google OAuth Sign-In (identity only, no service scopes)
+        $router->addRoute(
+            'claudriel.auth.google.signin',
+            RouteBuilder::create('/auth/google/signin')
+                ->controller(GoogleOAuthController::class.'::signin')
+                ->allowAll()
+                ->methods('GET')
+                ->build(),
+        );
+
+        $googleSigninCallbackRoute = RouteBuilder::create('/auth/google/signin/callback')
+            ->controller(GoogleOAuthController::class.'::signinCallback')
+            ->allowAll()
+            ->methods('GET')
+            ->build();
+        $googleSigninCallbackRoute->setOption('_csrf', false);
+        $router->addRoute('claudriel.auth.google.signin.callback', $googleSigninCallbackRoute);
+
         // GitHub OAuth
         $router->addRoute(
             'claudriel.auth.github.connect',

--- a/src/Service/PublicAccountSignupService.php
+++ b/src/Service/PublicAccountSignupService.php
@@ -103,6 +103,36 @@ final class PublicAccountSignupService
         ];
     }
 
+    public function createFromGoogle(string $email, string $name): Account
+    {
+        $email = strtolower(trim($email));
+        $name = trim($name);
+
+        $existing = $this->findAccountByEmail($email);
+        if ($existing instanceof Account) {
+            if ($existing->get('status') === 'pending_verification') {
+                $existing->set('status', 'active');
+                $existing->set('email_verified_at', (new \DateTimeImmutable)->format(\DateTimeInterface::ATOM));
+                $this->entityTypeManager->getStorage('account')->save($existing);
+            }
+
+            return $existing;
+        }
+
+        $account = new Account([
+            'name' => $name,
+            'email' => $email,
+            'password_hash' => null,
+            'status' => 'active',
+            'email_verified_at' => (new \DateTimeImmutable)->format(\DateTimeInterface::ATOM),
+            'roles' => [],
+            'permissions' => [],
+        ]);
+        $this->entityTypeManager->getStorage('account')->save($account);
+
+        return $account;
+    }
+
     public function findAccountByEmail(string $email): ?Account
     {
         $ids = $this->entityTypeManager->getStorage('account')->getQuery()

--- a/tests/Unit/Controller/GoogleOAuthSigninTest.php
+++ b/tests/Unit/Controller/GoogleOAuthSigninTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Controller;
+
+use Claudriel\Controller\GoogleOAuthController;
+use Claudriel\Entity\Account;
+use Claudriel\Entity\Integration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+
+final class GoogleOAuthSigninTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            @session_start();
+        }
+        $_SESSION = [];
+        $_ENV['GOOGLE_CLIENT_ID'] = 'test-client-id';
+        $_ENV['GOOGLE_CLIENT_SECRET'] = 'test-secret';
+        $_ENV['GOOGLE_REDIRECT_URI'] = 'https://claudriel.ai/auth/google/callback';
+        $_ENV['GOOGLE_SIGNIN_REDIRECT_URI'] = 'https://claudriel.ai/auth/google/signin/callback';
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        unset(
+            $_ENV['GOOGLE_CLIENT_ID'],
+            $_ENV['GOOGLE_CLIENT_SECRET'],
+            $_ENV['GOOGLE_REDIRECT_URI'],
+            $_ENV['GOOGLE_SIGNIN_REDIRECT_URI'],
+        );
+    }
+
+    public function test_signin_redirects_to_google_with_identity_scopes(): void
+    {
+        $controller = new GoogleOAuthController($this->buildEntityTypeManager());
+
+        $response = $controller->signin();
+
+        self::assertSame(302, $response->getStatusCode());
+        $location = $response->headers->get('Location');
+        self::assertStringContainsString('accounts.google.com', $location);
+        self::assertStringContainsString('openid', $location);
+        self::assertStringContainsString('userinfo.email', $location);
+        self::assertStringContainsString('userinfo.profile', $location);
+        self::assertStringNotContainsString('gmail', $location);
+        self::assertStringNotContainsString('calendar', $location);
+        self::assertStringContainsString('signin%2Fcallback', $location);
+    }
+
+    public function test_signin_sets_flow_session_variable(): void
+    {
+        $controller = new GoogleOAuthController($this->buildEntityTypeManager());
+
+        $controller->signin();
+
+        self::assertSame('signin', $_SESSION['google_oauth_flow']);
+        self::assertNotEmpty($_SESSION['google_oauth_state']);
+    }
+
+    private function buildEntityTypeManager(): EntityTypeManager
+    {
+        $db = DBALDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher;
+        $etm = new EntityTypeManager($dispatcher, function ($def) use ($db, $dispatcher) {
+            (new SqlSchemaHandler($def, $db))->ensureTable();
+
+            return new SqlEntityStorage($def, $db, $dispatcher);
+        });
+
+        $etm->registerEntityType(new EntityType(
+            id: 'integration',
+            label: 'Integration',
+            class: Integration::class,
+            keys: ['id' => 'iid', 'uuid' => 'uuid', 'label' => 'name'],
+        ));
+
+        $etm->registerEntityType(new EntityType(
+            id: 'account',
+            label: 'Account',
+            class: Account::class,
+            keys: ['id' => 'aid', 'uuid' => 'uuid', 'label' => 'name'],
+        ));
+
+        return $etm;
+    }
+}

--- a/tests/Unit/Service/PublicAccountSignupServiceGoogleTest.php
+++ b/tests/Unit/Service/PublicAccountSignupServiceGoogleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Service;
+
+use Claudriel\Entity\Account;
+use Claudriel\Service\PublicAccountSignupService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Waaseyaa\Database\DBALDatabase;
+use Waaseyaa\Entity\EntityType;
+use Waaseyaa\Entity\EntityTypeManager;
+use Waaseyaa\EntityStorage\SqlEntityStorage;
+use Waaseyaa\EntityStorage\SqlSchemaHandler;
+
+final class PublicAccountSignupServiceGoogleTest extends TestCase
+{
+    private EntityTypeManager $entityTypeManager;
+
+    private PublicAccountSignupService $service;
+
+    protected function setUp(): void
+    {
+        $this->entityTypeManager = $this->buildEntityTypeManager();
+        $this->service = new PublicAccountSignupService($this->entityTypeManager);
+    }
+
+    public function test_create_from_google_creates_active_account(): void
+    {
+        $account = $this->service->createFromGoogle('ada@example.com', 'Ada Lovelace');
+
+        self::assertInstanceOf(Account::class, $account);
+        self::assertSame('ada@example.com', $account->get('email'));
+        self::assertSame('Ada Lovelace', $account->get('name'));
+        self::assertNull($account->get('password_hash'));
+        self::assertSame('active', $account->get('status'));
+        self::assertNotNull($account->get('email_verified_at'));
+    }
+
+    public function test_create_from_google_returns_existing_account_if_email_matches(): void
+    {
+        $first = $this->service->createFromGoogle('ada@example.com', 'Ada Lovelace');
+        $second = $this->service->createFromGoogle('ada@example.com', 'Ada L');
+
+        self::assertSame($first->get('uuid'), $second->get('uuid'));
+    }
+
+    public function test_create_from_google_activates_pending_verification_account(): void
+    {
+        $storage = $this->entityTypeManager->getStorage('account');
+        $pending = new Account([
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+            'password_hash' => password_hash('secret', PASSWORD_DEFAULT),
+            'status' => 'pending_verification',
+            'roles' => [],
+            'permissions' => [],
+        ]);
+        $storage->save($pending);
+
+        $account = $this->service->createFromGoogle('ada@example.com', 'Ada Lovelace');
+
+        self::assertSame('active', $account->get('status'));
+        self::assertNotNull($account->get('email_verified_at'));
+        self::assertSame($pending->get('uuid'), $account->get('uuid'));
+    }
+
+    private function buildEntityTypeManager(): EntityTypeManager
+    {
+        $db = DBALDatabase::createSqlite(':memory:');
+        $dispatcher = new EventDispatcher;
+        $entityTypeManager = new EntityTypeManager($dispatcher, function ($definition) use ($db, $dispatcher): SqlEntityStorage {
+            (new SqlSchemaHandler($definition, $db))->ensureTable();
+
+            return new SqlEntityStorage($definition, $db, $dispatcher);
+        });
+
+        $entityTypeManager->registerEntityType(new EntityType(
+            id: 'account',
+            label: 'Account',
+            class: Account::class,
+            keys: ['id' => 'aid', 'uuid' => 'uuid', 'label' => 'name'],
+        ));
+
+        return $entityTypeManager;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `createFromGoogle()` to `PublicAccountSignupService` for password-less account creation
- Add `signin()` and `signinCallback()` to `GoogleOAuthController` with identity-only scopes (openid, email, profile)
- Register `/auth/google/signin` and `/auth/google/signin/callback` routes
- 5 new tests, all 696 passing

## Test plan
- [x] PHPStan: no errors
- [x] PHPUnit: 696 tests, 1903 assertions
- [ ] Manual: add `GOOGLE_SIGNIN_REDIRECT_URI` to .env and Google Cloud Console after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)