### PR TITLE
chore(#336): extract inline styles from homepage mockup to CSS classes

### DIFF
--- a/templates/public/homepage.twig
+++ b/templates/public/homepage.twig
@@ -281,6 +281,71 @@
     .value-card p {
         color: #c6cad7;
     }
+    .next-block-time {
+        color: var(--accent-teal);
+        font-size: 0.82rem;
+    }
+    .brief-greeting {
+        font-family: var(--font-display);
+        font-size: 1.35rem;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        line-height: 1.3;
+        margin-bottom: 0.6rem;
+    }
+    .brief-greeting-sub {
+        color: var(--text-secondary);
+    }
+    .brief-items {
+        display: grid;
+        gap: 0.5rem;
+    }
+    .brief-item {
+        display: flex;
+        gap: 0.65rem;
+        align-items: center;
+        padding: 0.65rem 0.8rem;
+        background: rgba(255,255,255,0.03);
+        border-radius: 0.5rem;
+        border-left: 2px solid var(--accent-amber);
+    }
+    .brief-item--teal {
+        border-left-color: var(--accent-teal);
+    }
+    .brief-item--blue {
+        border-left-color: var(--accent-blue);
+    }
+    .brief-item-num {
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: var(--accent-amber);
+    }
+    .brief-item--teal .brief-item-num {
+        color: var(--accent-teal);
+    }
+    .brief-item--blue .brief-item-num {
+        color: var(--accent-blue);
+    }
+    .brief-item-text {
+        font-size: 0.85rem;
+        color: var(--text-primary);
+    }
+    .home-footer {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 0 1.4rem 3rem;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.82rem;
+    }
+    .home-footer a {
+        color: var(--text-secondary);
+        text-decoration: underline;
+        text-underline-offset: 2px;
+    }
+    .home-footer-dot {
+        margin: 0 0.5rem;
+    }
     @media (max-width: 980px) {
         .hero {
             grid-template-columns: 1fr;
@@ -353,28 +418,28 @@
                             <div class="mini-panel">
                                 <h3>Next block</h3>
                                 <div>Client review</div>
-                                <div style="color: var(--accent-teal); font-size: 0.82rem;">in 35 min</div>
+                                <div class="next-block-time">in 35 min</div>
                             </div>
                         </aside>
 
                         <div class="frame-main">
-                            <div style="font-family: var(--font-display); font-size: 1.35rem; font-weight: 600; letter-spacing: -0.02em; line-height: 1.3; margin-bottom: 0.6rem;">
+                            <div class="brief-greeting">
                                 Good morning.<br>
-                                <span style="color: var(--text-secondary);">Three things before your first call.</span>
+                                <span class="brief-greeting-sub">Three things before your first call.</span>
                             </div>
 
-                            <div style="display: grid; gap: 0.5rem;">
-                                <div style="display: flex; gap: 0.65rem; align-items: center; padding: 0.65rem 0.8rem; background: rgba(255,255,255,0.03); border-radius: 0.5rem; border-left: 2px solid var(--accent-amber);">
-                                    <span style="font-size: 0.8rem; color: var(--accent-amber); font-weight: 600;">1</span>
-                                    <span style="font-size: 0.85rem; color: var(--text-primary);">Review Acme proposal (Sarah flagged timeline)</span>
+                            <div class="brief-items">
+                                <div class="brief-item">
+                                    <span class="brief-item-num">1</span>
+                                    <span class="brief-item-text">Review Acme proposal (Sarah flagged timeline)</span>
                                 </div>
-                                <div style="display: flex; gap: 0.65rem; align-items: center; padding: 0.65rem 0.8rem; background: rgba(255,255,255,0.03); border-radius: 0.5rem; border-left: 2px solid var(--accent-teal);">
-                                    <span style="font-size: 0.8rem; color: var(--accent-teal); font-weight: 600;">2</span>
-                                    <span style="font-size: 0.85rem; color: var(--text-primary);">Two commitments drifting past 48h</span>
+                                <div class="brief-item brief-item--teal">
+                                    <span class="brief-item-num">2</span>
+                                    <span class="brief-item-text">Two commitments drifting past 48h</span>
                                 </div>
-                                <div style="display: flex; gap: 0.65rem; align-items: center; padding: 0.65rem 0.8rem; background: rgba(255,255,255,0.03); border-radius: 0.5rem; border-left: 2px solid var(--accent-blue);">
-                                    <span style="font-size: 0.8rem; color: var(--accent-blue); font-weight: 600;">3</span>
-                                    <span style="font-size: 0.85rem; color: var(--text-primary);">Clear block until 2pm: deep work window</span>
+                                <div class="brief-item brief-item--blue">
+                                    <span class="brief-item-num">3</span>
+                                    <span class="brief-item-text">Clear block until 2pm: deep work window</span>
                                 </div>
                             </div>
                         </div>
@@ -398,11 +463,11 @@
             </article>
         </section>
 
-        <footer style="max-width: 1180px; margin: 0 auto; padding: 0 1.4rem 3rem; text-align: center; color: var(--text-muted); font-size: 0.82rem;">
-            <a href="/privacy" style="color: var(--text-secondary); text-decoration: underline; text-underline-offset: 2px;">Privacy Policy</a>
-            <span style="margin: 0 0.5rem;">&middot;</span>
-            <a href="/terms" style="color: var(--text-secondary); text-decoration: underline; text-underline-offset: 2px;">Terms</a>
-            <span style="margin: 0 0.5rem;">&middot;</span>
+        <footer class="home-footer">
+            <a href="/privacy">Privacy Policy</a>
+            <span class="home-footer-dot">&middot;</span>
+            <a href="/terms">Terms</a>
+            <span class="home-footer-dot">&middot;</span>
             <span>&copy; {{ "now"|date("Y") }} Claudriel</span>
         </footer>
     </main>


### PR DESCRIPTION
## Summary
- Extract all inline styles from homepage mockup section to named CSS classes
- Extract footer inline styles to `.home-footer` class
- No visual changes, purely a maintainability improvement

Closes #336

## Test plan
- [ ] Load homepage — visual appearance identical to before
- [ ] Check mobile responsive layout unchanged
- [ ] Verify no remaining inline `style` attributes in frame-main or footer sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)