### PR TITLE
feat(#383): add live clock to admin dashboard header

### DIFF
--- a/frontend/admin/app/components/layout/AdminShell.vue
+++ b/frontend/admin/app/components/layout/AdminShell.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useLanguage } from '~/composables/useLanguage'
+import { useClock } from '~/composables/useClock'
 
 const { t, locale, locales, setLocale } = useLanguage()
+const { formatted: clockTime } = useClock()
 const config = useRuntimeConfig()
 const appName = config.public.appName as string
 const isDesktop = ref(false)
@@ -48,6 +50,7 @@ async function handleLogout() {
         <span class="topbar-toggle-icon">&#9776;</span>
       </button>
       <NuxtLink to="/" class="topbar-brand">{{ appName }}</NuxtLink>
+      <span class="topbar-clock">{{ clockTime }}</span>
       <button class="topbar-logout" type="button" @click="handleLogout">
         {{ t('logout') }}
       </button>
@@ -163,6 +166,13 @@ body {
   font-weight: 700;
   font-size: 16px;
   letter-spacing: -0.02em;
+}
+
+.topbar-clock {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+  white-space: nowrap;
   margin-right: auto;
 }
 
@@ -347,6 +357,10 @@ body {
 
 /* Responsive layout */
 @media (max-width: 768px) {
+  .topbar-clock {
+    display: none;
+  }
+
   .topbar-toggle {
     display: inline-flex;
     align-items: center;

--- a/frontend/admin/app/composables/useClock.ts
+++ b/frontend/admin/app/composables/useClock.ts
@@ -1,0 +1,31 @@
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+
+export function useClock() {
+  const now = ref(new Date())
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  const formatted = computed(() =>
+    now.value.toLocaleString(undefined, {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZoneName: 'short',
+    }),
+  )
+
+  onMounted(() => {
+    timer = setInterval(() => {
+      now.value = new Date()
+    }, 1000)
+  })
+
+  onUnmounted(() => {
+    if (timer) clearInterval(timer)
+  })
+
+  return { formatted }
+}


### PR DESCRIPTION
## Summary
- Add `useClock` composable with 1-second interval and `Intl`-based formatting
- Display live clock in topbar between brand name and logout button
- Hidden on mobile (< 768px) to save space
- Uses browser locale for date/time formatting and timezone

Closes #383

## Test plan
- [ ] Load /admin/ — clock visible in topbar
- [ ] Clock ticks every second
- [ ] Resize to mobile — clock hidden
- [ ] Date format includes weekday, full date, time with seconds, and timezone abbreviation

🤖 Generated with [Claude Code](https://claude.com/claude-code)