### PR TITLE
chore(#337): use user timezone for dashboard greeting

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -163,6 +163,7 @@ final class DashboardController
                 'proactive_guidance' => $proactiveGuidance,
                 'brief_fallback_payload' => json_encode($fallbackPayload, JSON_THROW_ON_ERROR),
                 'brief_fallback_url' => '/stream/brief?transport=fallback&request_id='.$requestId,
+                'local_hour' => (int) $snapshot->local()->format('G'),
             ]));
 
             return new SsrResponse(

--- a/templates/dashboard.twig
+++ b/templates/dashboard.twig
@@ -1228,7 +1228,7 @@
             </div>
 
             {# ── Editorial Greeting ── #}
-            {% set hour = "now"|date("G") %}
+            {% set hour = local_hour|default("now"|date("G")) %}
             {% set greeting = hour < 12 ? 'Good morning.' : (hour < 17 ? 'Good afternoon.' : 'Good evening.') %}
             {% set attention_count = (pending_commitments|default([]))|length + (drifting_commitments|default([]))|length %}
 


### PR DESCRIPTION
## Summary
- Pass `local_hour` from `TimeSnapshot` to the dashboard Twig template
- Greeting now uses the user's resolved timezone instead of server default
- Falls back to server time if `local_hour` is not provided

Closes #337

## Test plan
- [ ] Load dashboard with `?timezone=America/New_York` — greeting matches Eastern time
- [ ] Load dashboard without timezone param — greeting uses server timezone (backward compat)
- [ ] PHPStan passes

> **Note:** Pre-push hook flagged a pre-existing flaky test (`CommitmentExtractionAuditTrendsTest::test_monthly_trends_roll_up_by_month`) that also fails on `main` — it's a date-boundary issue where `-55 days` and `-29 days` can land in the same month depending on the current date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)