### PR TITLE
fix(#555): add shimmer animation to SPA loading skeleton

### DIFF
--- a/frontend/admin/app/spa-loading-template.html
+++ b/frontend/admin/app/spa-loading-template.html
@@ -1,31 +1,35 @@
+<style>
+.skel-box{animation:skel-shimmer 1.5s ease-in-out infinite}
+@keyframes skel-shimmer{0%,100%{opacity:1}50%{opacity:.4}}
+</style>
 <div style="display:flex;flex-direction:column;min-height:100vh;background:#0a0c10;color:#e8e9ed;font-family:'DM Sans',system-ui,sans-serif">
   <header style="height:48px;background:#131620;border-bottom:1px solid rgba(255,255,255,0.06);display:flex;align-items:center;padding:0 16px">
     <span style="font-family:'Bricolage Grotesque',system-ui,sans-serif;font-weight:700;font-size:16px;letter-spacing:-0.02em">Claudriel Admin</span>
   </header>
   <div style="display:flex;flex:1">
     <aside style="width:220px;background:#131620;border-right:1px solid rgba(255,255,255,0.06);padding:16px 0">
-      <div style="padding:8px 16px;height:16px;width:60%;background:rgba(255,255,255,0.04);border-radius:4px;margin-bottom:16px"></div>
+      <div class="skel-box" style="padding:8px 16px;height:16px;width:60%;background:rgba(255,255,255,0.04);border-radius:4px;margin-bottom:16px"></div>
       <div style="padding:0 16px;display:flex;flex-direction:column;gap:6px">
-        <div style="height:12px;width:50%;background:rgba(255,255,255,0.06);border-radius:3px"></div>
-        <div style="height:32px;width:80%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
-        <div style="height:12px;width:50%;background:rgba(255,255,255,0.06);border-radius:3px;margin-top:8px"></div>
-        <div style="height:32px;width:70%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
-        <div style="height:32px;width:60%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
-        <div style="height:12px;width:50%;background:rgba(255,255,255,0.06);border-radius:3px;margin-top:8px"></div>
-        <div style="height:32px;width:75%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
-        <div style="height:32px;width:85%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
-        <div style="height:32px;width:65%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
+        <div class="skel-box" style="height:12px;width:50%;background:rgba(255,255,255,0.06);border-radius:3px"></div>
+        <div class="skel-box" style="height:32px;width:80%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
+        <div class="skel-box" style="height:12px;width:50%;background:rgba(255,255,255,0.06);border-radius:3px;margin-top:8px"></div>
+        <div class="skel-box" style="height:32px;width:70%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
+        <div class="skel-box" style="height:32px;width:60%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
+        <div class="skel-box" style="height:12px;width:50%;background:rgba(255,255,255,0.06);border-radius:3px;margin-top:8px"></div>
+        <div class="skel-box" style="height:32px;width:75%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
+        <div class="skel-box" style="height:32px;width:85%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
+        <div class="skel-box" style="height:32px;width:65%;background:rgba(255,255,255,0.03);border-radius:4px"></div>
       </div>
     </aside>
     <main style="flex:1;padding:24px">
-      <div style="height:28px;width:200px;background:rgba(255,255,255,0.04);border-radius:4px;margin-bottom:24px"></div>
+      <div class="skel-box" style="height:28px;width:200px;background:rgba(255,255,255,0.04);border-radius:4px;margin-bottom:24px"></div>
       <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px">
-        <div style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
-        <div style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
-        <div style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
-        <div style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
-        <div style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
-        <div style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
+        <div class="skel-box" style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
+        <div class="skel-box" style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
+        <div class="skel-box" style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
+        <div class="skel-box" style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
+        <div class="skel-box" style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
+        <div class="skel-box" style="height:80px;background:#131620;border:1px solid rgba(255,255,255,0.06);border-radius:10px"></div>
       </div>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- Add CSS shimmer animation to the static `spa-loading-template.html`
- Skeleton placeholders now pulse during the 5-8 second hydration window
- Matches the existing shimmer in `app.vue`'s Vue-based skeleton

Closes #555

## Test plan
- [ ] Load /admin/ — skeleton with shimmer animation visible before Vue hydrates
- [ ] No blank white page during load
- [ ] Animation transitions smoothly to Vue skeleton then to real content

🤖 Generated with [Claude Code](https://claude.com/claude-code)