### PR TITLE
fix(#557): update waaseyaa/graphql with auto-inject account context

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4880,12 +4880,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/waaseyaa/graphql.git",
-                "reference": "43496c8cec770b651e435ae17ad79f709d63a314"
+                "reference": "0eedf4d8a2c156d85b3fdb4b31f9815f1cd67fc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/waaseyaa/graphql/zipball/43496c8cec770b651e435ae17ad79f709d63a314",
-                "reference": "43496c8cec770b651e435ae17ad79f709d63a314",
+                "url": "https://api.github.com/repos/waaseyaa/graphql/zipball/0eedf4d8a2c156d85b3fdb4b31f9815f1cd67fc1",
+                "reference": "0eedf4d8a2c156d85b3fdb4b31f9815f1cd67fc1",
                 "shasum": ""
             },
             "require": {
@@ -4920,9 +4920,9 @@
             "description": "GraphQL endpoint for Waaseyaa — auto-generated schema from entity types",
             "support": {
                 "issues": "https://github.com/waaseyaa/graphql/issues",
-                "source": "https://github.com/waaseyaa/graphql/tree/v0.1.0-alpha.61"
+                "source": "https://github.com/waaseyaa/graphql/tree/v0.1.0-alpha.62"
             },
-            "time": "2026-03-28T00:05:51+00:00"
+            "time": "2026-03-28T00:45:49+00:00"
         },
         {
             "name": "waaseyaa/i18n",


### PR DESCRIPTION
## Summary
- Pull upstream fix (waaseyaa/framework#683) that auto-populates `account_id` and `tenant_id` on GraphQL create mutations
- Fixes workspace creation timeout: new workspaces were invisible to access policies because they had no `account_id`
- Framework-level fix benefits all entity types with `account_id`/`tenant_id` fields

Closes #557

## Test plan
- [ ] Create workspace via admin form — no timeout, workspace visible immediately
- [ ] Create commitment via admin form — `tenant_id` auto-populated
- [ ] Explicit `account_id` in input is preserved (not overwritten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)