### PR TITLE
feat(#293): add importance-based ranking to DayBriefAssembler

### DIFF
--- a/src/Domain/DayBrief/Assembler/DayBriefAssembler.php
+++ b/src/Domain/DayBrief/Assembler/DayBriefAssembler.php
@@ -138,15 +138,15 @@ final class DayBriefAssembler
 
         /** @var ContentEntityInterface[] $allCommitments */
         $allCommitments = $this->commitmentRepo->findBy([]);
-        $pending = array_values(array_filter(
+        $pending = $this->sortByImportanceDesc(array_values(array_filter(
             $allCommitments,
             fn (ContentEntityInterface $c) => $this->entityMatchesTenant($c, $tenantId) && ($c->get('workflow_state') ?? $c->get('status')) === 'pending',
-        ));
-        $drifting = $this->driftDetector->findDrifting($tenantId);
-        $waitingOn = array_values(array_filter(
+        )));
+        $drifting = $this->sortByImportanceDesc($this->driftDetector->findDrifting($tenantId));
+        $waitingOn = $this->sortByImportanceDesc(array_values(array_filter(
             $pending,
             static fn (ContentEntityInterface $c) => $c->get('direction') === 'inbound',
-        ));
+        )));
 
         $followUps = $this->followUpMonitor !== null
             ? $this->followUpMonitor->findUnanswered($tenantId)
@@ -528,7 +528,15 @@ final class DayBriefAssembler
             },
         ));
 
-        usort($people, fn ($a, $b): int => ((string) $this->getEntityValue($b, 'last_interaction_at')) <=> ((string) $this->getEntityValue($a, 'last_interaction_at')));
+        usort($people, function ($a, $b): int {
+            $scoreA = is_numeric($this->getEntityValue($a, 'importance_score')) ? (float) $this->getEntityValue($a, 'importance_score') : 1.0;
+            $scoreB = is_numeric($this->getEntityValue($b, 'importance_score')) ? (float) $this->getEntityValue($b, 'importance_score') : 1.0;
+            if ($scoreB !== $scoreA) {
+                return $scoreB <=> $scoreA;
+            }
+
+            return ((string) $this->getEntityValue($b, 'last_interaction_at')) <=> ((string) $this->getEntityValue($a, 'last_interaction_at'));
+        });
 
         return array_map(fn ($person): array => [
             'person_name' => (string) ($this->getEntityValue($person, 'name') ?? $this->getEntityValue($person, 'email') ?? ''),
@@ -687,6 +695,22 @@ final class DayBriefAssembler
         }
 
         return $matched;
+    }
+
+    /**
+     * @param ContentEntityInterface[] $entities
+     * @return ContentEntityInterface[]
+     */
+    private function sortByImportanceDesc(array $entities): array
+    {
+        usort($entities, function (ContentEntityInterface $a, ContentEntityInterface $b): int {
+            $scoreA = is_numeric($a->get('importance_score')) ? (float) $a->get('importance_score') : 1.0;
+            $scoreB = is_numeric($b->get('importance_score')) ? (float) $b->get('importance_score') : 1.0;
+
+            return $scoreB <=> $scoreA;
+        });
+
+        return $entities;
     }
 
     private function entityMatchesTenant(mixed $entity, string $tenantId): bool

--- a/tests/Unit/DayBrief/DayBriefAssemblerTest.php
+++ b/tests/Unit/DayBrief/DayBriefAssemblerTest.php
@@ -505,6 +505,56 @@ final class DayBriefAssemblerTest extends TestCase
         self::assertSame(1, $brief['counts']['waiting_on']);
     }
 
+    public function test_pending_commitments_sorted_by_importance_score_descending(): void
+    {
+        $low = new Commitment(['cid' => 1, 'uuid' => 'c-low', 'title' => 'Low', 'workflow_state' => 'pending', 'status' => 'pending', 'tenant_id' => 'test-tenant', 'importance_score' => 0.3]);
+        $high = new Commitment(['cid' => 2, 'uuid' => 'c-high', 'title' => 'High', 'workflow_state' => 'pending', 'status' => 'pending', 'tenant_id' => 'test-tenant', 'importance_score' => 0.9]);
+        $mid = new Commitment(['cid' => 3, 'uuid' => 'c-mid', 'title' => 'Mid', 'workflow_state' => 'pending', 'status' => 'pending', 'tenant_id' => 'test-tenant', 'importance_score' => 0.6]);
+
+        $this->commitmentRepo->save($low);
+        $this->commitmentRepo->save($high);
+        $this->commitmentRepo->save($mid);
+
+        $result = $this->assembler->assemble('test-tenant', new \DateTimeImmutable('-7 days'));
+
+        $pending = $result['commitments']['pending'];
+        self::assertCount(3, $pending);
+        self::assertSame('c-high', $pending[0]->get('uuid'));
+        self::assertSame('c-mid', $pending[1]->get('uuid'));
+        self::assertSame('c-low', $pending[2]->get('uuid'));
+    }
+
+    public function test_people_sorted_by_importance_score_descending(): void
+    {
+        $now = new \DateTimeImmutable;
+        $lowImportance = new Person([
+            'pid' => 1, 'uuid' => 'p-low', 'name' => 'Low',
+            'email' => 'low@test.com', 'tenant_id' => 'test-tenant',
+            'last_inbox_category' => 'people',
+            'last_interaction_at' => $now->format('c'),
+            'latest_summary' => 'Test',
+            'importance_score' => 0.2,
+        ]);
+        $highImportance = new Person([
+            'pid' => 2, 'uuid' => 'p-high', 'name' => 'High',
+            'email' => 'high@test.com', 'tenant_id' => 'test-tenant',
+            'last_inbox_category' => 'people',
+            'last_interaction_at' => $now->format('c'),
+            'latest_summary' => 'Test',
+            'importance_score' => 0.9,
+        ]);
+
+        $this->personRepo->save($lowImportance);
+        $this->personRepo->save($highImportance);
+
+        $result = $this->assembler->assemble('test-tenant', new \DateTimeImmutable('-7 days'));
+
+        $people = $result['people'];
+        self::assertCount(2, $people);
+        self::assertSame('High', $people[0]['person_name']);
+        self::assertSame('Low', $people[1]['person_name']);
+    }
+
     public function test_brief_includes_unanswered_follow_ups(): void
     {
         // Seed a sent event 5 days ago with no reply


### PR DESCRIPTION
## Summary
- Sort pending/drifting/waiting_on commitments by `importance_score` descending in `DayBriefAssembler::assemble()`
- Sort people by `importance_score` (primary) then `last_interaction_at` (secondary) in `buildNormalizedPeople()`
- Add private `sortByImportanceDesc()` helper for entity arrays
- Entities without explicit `importance_score` default to 1.0 (maximally important, preserving existing behavior)

## Test plan
- [x] `test_pending_commitments_sorted_by_importance_score_descending` verifies high/mid/low ordering
- [x] `test_people_sorted_by_importance_score_descending` verifies people with equal timestamps sort by score
- [x] Full DayBrief suite passes (32 tests, 113 assertions)

Closes #293 (Unit 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)