### PR TITLE
feat: add SpecialistListTool — list_specialists agent tool

### DIFF
--- a/src/Domain/Chat/Tool/SpecialistListTool.php
+++ b/src/Domain/Chat/Tool/SpecialistListTool.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Domain\Chat\Tool;
+
+use Claudriel\Domain\Chat\AgentToolInterface;
+
+final class SpecialistListTool implements AgentToolInterface
+{
+    private \Closure $httpGet;
+
+    public function __construct(
+        private readonly string $baseUrl,
+        ?\Closure $httpGet = null,
+    ) {
+        $this->httpGet = $httpGet ?? static function (string $url): string|false {
+            $context = stream_context_create([
+                'http' => [
+                    'method' => 'GET',
+                    'header' => "Accept: application/json\r\n",
+                    'timeout' => 10,
+                    'ignore_errors' => true,
+                ],
+            ]);
+
+            return file_get_contents($url, false, $context);
+        };
+    }
+
+    public function definition(): array
+    {
+        return [
+            'name' => 'list_specialists',
+            'description' => 'List available specialists from the agency, optionally filtered by query or division.',
+            'input_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'query' => [
+                        'type' => 'string',
+                        'description' => 'Search query to filter specialists by name or capability',
+                    ],
+                    'division' => [
+                        'type' => 'string',
+                        'description' => 'Filter by division name',
+                    ],
+                    'limit' => [
+                        'type' => 'integer',
+                        'description' => 'Max results (default: 10, max: 50)',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function execute(array $args): array
+    {
+        $limit = min((int) ($args['limit'] ?? 10), 50);
+
+        $params = ['limit' => $limit];
+        if (isset($args['query']) && is_string($args['query']) && $args['query'] !== '') {
+            $params['q'] = $args['query'];
+        }
+        if (isset($args['division']) && is_string($args['division']) && $args['division'] !== '') {
+            $params['division'] = $args['division'];
+        }
+
+        $url = rtrim($this->baseUrl, '/').'/v1/agents?'.http_build_query($params);
+
+        try {
+            $response = ($this->httpGet)($url);
+            if ($response === false) {
+                return ['error' => 'Specialist service unavailable'];
+            }
+
+            $data = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+
+            $specialists = $data['data'] ?? $data['agents'] ?? $data;
+            if (! is_array($specialists)) {
+                $specialists = [];
+            }
+
+            return [
+                'specialists' => $specialists,
+                'total' => count($specialists),
+            ];
+        } catch (\Throwable) {
+            return ['error' => 'Specialist service unavailable'];
+        }
+    }
+}

--- a/tests/Unit/Domain/Chat/Tool/SpecialistListToolTest.php
+++ b/tests/Unit/Domain/Chat/Tool/SpecialistListToolTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Claudriel\Tests\Unit\Domain\Chat\Tool;
+
+use Claudriel\Domain\Chat\Tool\SpecialistListTool;
+use PHPUnit\Framework\TestCase;
+
+final class SpecialistListToolTest extends TestCase
+{
+    public function test_definition_has_required_fields(): void
+    {
+        $tool = new SpecialistListTool('http://localhost:9999');
+        $def = $tool->definition();
+
+        self::assertSame('list_specialists', $def['name']);
+        self::assertArrayHasKey('description', $def);
+        self::assertArrayHasKey('input_schema', $def);
+        self::assertArrayHasKey('properties', $def['input_schema']);
+        self::assertArrayHasKey('query', $def['input_schema']['properties']);
+        self::assertArrayHasKey('division', $def['input_schema']['properties']);
+        self::assertArrayHasKey('limit', $def['input_schema']['properties']);
+    }
+
+    public function test_definition_has_no_required_params(): void
+    {
+        $tool = new SpecialistListTool('http://localhost:9999');
+        $def = $tool->definition();
+
+        self::assertArrayNotHasKey('required', $def['input_schema']);
+    }
+
+    public function test_execute_builds_correct_url_with_params(): void
+    {
+        $capturedUrl = null;
+        $httpGet = static function (string $url) use (&$capturedUrl): string {
+            $capturedUrl = $url;
+
+            return json_encode(['data' => []]);
+        };
+
+        $tool = new SpecialistListTool('http://agency.test', $httpGet);
+        $tool->execute(['query' => 'php', 'division' => 'engineering', 'limit' => 5]);
+
+        self::assertNotNull($capturedUrl);
+        self::assertStringContainsString('/v1/agents?', $capturedUrl);
+        self::assertStringContainsString('q=php', $capturedUrl);
+        self::assertStringContainsString('division=engineering', $capturedUrl);
+        self::assertStringContainsString('limit=5', $capturedUrl);
+    }
+
+    public function test_execute_returns_specialists_from_api(): void
+    {
+        $agents = [
+            ['id' => 'a1', 'name' => 'Alice', 'division' => 'eng'],
+            ['id' => 'a2', 'name' => 'Bob', 'division' => 'eng'],
+        ];
+        $httpGet = static fn (string $url): string => json_encode(['data' => $agents]);
+
+        $tool = new SpecialistListTool('http://agency.test', $httpGet);
+        $result = $tool->execute([]);
+
+        self::assertArrayHasKey('specialists', $result);
+        self::assertArrayHasKey('total', $result);
+        self::assertCount(2, $result['specialists']);
+        self::assertSame(2, $result['total']);
+        self::assertSame('Alice', $result['specialists'][0]['name']);
+    }
+
+    public function test_execute_returns_error_on_http_failure(): void
+    {
+        $httpGet = static fn (string $url): false => false;
+
+        $tool = new SpecialistListTool('http://agency.test', $httpGet);
+        $result = $tool->execute([]);
+
+        self::assertArrayHasKey('error', $result);
+        self::assertSame('Specialist service unavailable', $result['error']);
+    }
+
+    public function test_execute_defaults_limit_to_10(): void
+    {
+        $capturedUrl = null;
+        $httpGet = static function (string $url) use (&$capturedUrl): string {
+            $capturedUrl = $url;
+
+            return json_encode(['data' => []]);
+        };
+
+        $tool = new SpecialistListTool('http://agency.test', $httpGet);
+        $tool->execute([]);
+
+        self::assertNotNull($capturedUrl);
+        self::assertStringContainsString('limit=10', $capturedUrl);
+    }
+
+    public function test_execute_caps_limit_at_50(): void
+    {
+        $capturedUrl = null;
+        $httpGet = static function (string $url) use (&$capturedUrl): string {
+            $capturedUrl = $url;
+
+            return json_encode(['data' => []]);
+        };
+
+        $tool = new SpecialistListTool('http://agency.test', $httpGet);
+        $tool->execute(['limit' => 200]);
+
+        self::assertNotNull($capturedUrl);
+        self::assertStringContainsString('limit=50', $capturedUrl);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SpecialistListTool` implementing `AgentToolInterface`
- Searches and filters 180+ specialist AI agents via the agency-agents REST API
- Gated by `AGENCY_AGENTS_URL` env var (tool not registered if unset)
- 6 unit tests with mocked HTTP

## Test plan
- [ ] `vendor/bin/phpunit tests/Unit/Domain/Chat/Tool/SpecialistListToolTest.php` passes
- [ ] Full test suite has no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)